### PR TITLE
Update API for Triton v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Triton 2.6.4
+# Triton 2.7.0
 [![Release](https://jitpack.io/v/diogotcorreia/Triton.svg)](https://jitpack.io/#diogotcorreia/Triton)  
 
 _Translate your server! Sends the same message on different languages... Hooks into all plugins!_  
@@ -7,7 +7,7 @@ This repository was previously called MultiLanguagePlugin.
 Buy it [here](https://www.spigotmc.org/resources/triton.30331/)!
 
 
-[Download API for Triton 2.6.4](https://cdn.rexcantor64.com/triton/api/TritonAPI-v2.5.0.jar) or [add it to your project using Gradle/Maven](https://jitpack.io/#diogotcorreia/Triton).
+[Download API for Triton 2.7.0](https://cdn.rexcantor64.com/triton/api/TritonAPI-v2.7.0.jar) or [add it to your project using Gradle/Maven](https://jitpack.io/#diogotcorreia/Triton).
 
 Need help developing? Take a look at the [JavaDocs](https://triton.rexcantor64.com/javadocs) or join our [Discord](https://triton.rexcantor64.com/discord)!
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
-# Triton 2.7.0
-[![Release](https://jitpack.io/v/diogotcorreia/Triton.svg)](https://jitpack.io/#diogotcorreia/Triton)  
+# Triton 3.0.0
+[![Release](https://jitpack.io/v/diogotcorreia/Triton.svg)](https://jitpack.io/#tritonmc/Triton)  
 
 _Translate your server! Sends the same message on different languages... Hooks into all plugins!_  
 This repository was previously called MultiLanguagePlugin.
 
-Buy it [here](https://www.spigotmc.org/resources/triton.30331/)!
+Triton is a Minecraft plugin for Spigot and BungeeCord that helps you translate your Minecraft server!
 
+Purchase the plugin on [Spigot](https://spigotmc.org/resources/triton.30331/) or [Polymart](https://polymart.org/resource/triton.38)!
 
-[Download API for Triton 2.7.0](https://cdn.rexcantor64.com/triton/api/TritonAPI-v2.7.0.jar) or [add it to your project using Gradle/Maven](https://jitpack.io/#diogotcorreia/Triton).
+## Using the API
+
+[Download the latest API from the releases tab](https://github.com/tritonmc/Triton/releases/latest) or [add it to your project using Gradle/Maven](https://jitpack.io/#tritonmc/Triton).
 
 Need help developing? Take a look at the [JavaDocs](https://triton.rexcantor64.com/javadocs) or join our [Discord](https://triton.rexcantor64.com/discord)!
 
-Looking for old API versions? Take a look at the [download page](https://github.com/diogotcorreia/Triton/wiki/Downloads)!
+Looking for older API versions? Take a look at the [download page](https://github.com/diogotcorreia/Triton/wiki/Downloads)!

--- a/pom.xml
+++ b/pom.xml
@@ -6,16 +6,16 @@
 
     <groupId>com.rexcantor64.triton</groupId>
     <artifactId>api</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <properties>
         <build.number/>
         <plugin.version>${project.version}-${build.number}</plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <scm>
-        <connection>scm:git:git@github.com:Rexcantor/Triton.git</connection>
-        <developerConnection>scm:git:git@github.com:Rexcantor/Triton.git</developerConnection>
-        <url>https://github.com/Rexcantor/Triton</url>
+        <connection>scm:git:git@github.com:tritonmc/Triton.git</connection>
+        <developerConnection>scm:git:git@github.com:tritonmc/Triton.git</developerConnection>
+        <url>https://github.com/tritonmc/Triton</url>
         <tag>HEAD</tag>
     </scm>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.rexcantor64.triton</groupId>
     <artifactId>api</artifactId>
-    <version>2.7.0</version>
+    <version>3.0.0</version>
     <properties>
         <build.number/>
         <plugin.version>${project.version}-${build.number}</plugin.version>

--- a/src/main/java/com/rexcantor64/triton/api/Triton.java
+++ b/src/main/java/com/rexcantor64/triton/api/Triton.java
@@ -21,6 +21,15 @@ public interface Triton {
     TritonConfig getConf();
 
     /**
+     * Get the {@link TritonConfig config}.
+     * Alias of {@link Triton#getConf()}
+     *
+     * @return The {@link TritonConfig config}.
+     * @since 3.0.0
+     */
+    TritonConfig getConfig();
+
+    /**
      * Get the {@link LanguageManager language manager}.
      *
      * @return The {@link LanguageManager language manager}.

--- a/src/main/java/com/rexcantor64/triton/api/Triton.java
+++ b/src/main/java/com/rexcantor64/triton/api/Triton.java
@@ -2,6 +2,7 @@ package com.rexcantor64.triton.api;
 
 import com.rexcantor64.triton.api.config.TritonConfig;
 import com.rexcantor64.triton.api.language.LanguageManager;
+import com.rexcantor64.triton.api.language.LanguageParser;
 import com.rexcantor64.triton.api.players.LanguagePlayer;
 import com.rexcantor64.triton.api.players.PlayerManager;
 
@@ -36,6 +37,14 @@ public interface Triton {
      * @since 1.0.0
      */
     LanguageManager getLanguageManager();
+
+    /**
+     * Get the {@link LanguageParser language parser}.
+     *
+     * @return The {@link LanguageParser language parser}.
+     * @since 3.0.0
+     */
+    LanguageParser getLanguageParser();
 
     /**
      * Get the {@link PlayerManager player manager}.

--- a/src/main/java/com/rexcantor64/triton/api/config/TritonConfig.java
+++ b/src/main/java/com/rexcantor64/triton/api/config/TritonConfig.java
@@ -32,6 +32,12 @@ public interface TritonConfig {
     boolean isBungeecord();
 
     /**
+     * @return The value of "log-level" in the config.
+     * @since 3.0.0
+     */
+    int getLogLevel();
+
+    /**
      * @return The value of "language-creation.disabled-line" in the config.
      * @since 1.0.0
      */
@@ -68,6 +74,7 @@ public interface TritonConfig {
      *
      * @return The value of "language-creation.scoreboards.enabled" in the config.
      * @since 1.0.0
+     * @deprecated Scoreboard translation has been removed in v3.0.0 and this will always return false from now on.
      */
     boolean isScoreboards();
 
@@ -76,6 +83,7 @@ public interface TritonConfig {
      *
      * @return The value of "language-creation.scoreboards.advanced" in the config.
      * @since 1.0.0
+     * @deprecated Scoreboard translation has been removed in v3.0.0 and this will always return false from now on.
      */
     boolean isScoreboardsAdvanced();
 
@@ -152,8 +160,16 @@ public interface TritonConfig {
      *
      * @return The value of "database.enabled" in the config.
      * @since 2.6.0
+     * @deprecated This has been deprecated since v3.0.0 in favor of {@link #getStorageType()}
      */
     boolean isMysql();
+
+    /**
+     * Get the storage type currently in use by the server.
+     *
+     * @return The string value of the storage type in use. ('local' or 'mysql')
+     */
+    String getStorageType();
 
     /**
      * @return The value of "language-creation.motd.enabled" in the config.
@@ -166,6 +182,14 @@ public interface TritonConfig {
      * @since 2.6.0
      */
     boolean isTerminal();
+
+    /**
+     * Spigot only
+     *
+     * @return The value of "language-creation.prevent-placeholders-in-chat" in the config.
+     * @since 3.0.0
+     */
+    boolean isPreventPlaceholdersInChat();
 
     /**
      * @return The {@link com.rexcantor64.triton.api.config.FeatureSyntax FeatureSyntax} of "language-creation.chat"
@@ -203,6 +227,8 @@ public interface TritonConfig {
      * @return The {@link com.rexcantor64.triton.api.config.FeatureSyntax FeatureSyntax} of "language-creation
      * .scoreboards" in the config.
      * @since 1.0.0
+     * @deprecated Scoreboard translation has been removed in v3.0.0 and this will always return a default
+     * {@link com.rexcantor64.triton.api.config.FeatureSyntax FeatureSyntax} from now on.
      */
     FeatureSyntax getScoreboardSyntax();
 

--- a/src/main/java/com/rexcantor64/triton/api/language/LanguageManager.java
+++ b/src/main/java/com/rexcantor64/triton/api/language/LanguageManager.java
@@ -36,6 +36,18 @@ public interface LanguageManager {
     String getText(LanguagePlayer player, String code, Object... args);
 
     /**
+     * Get a message from its code in a player's language.
+     *
+     * @param language The name of the {@link Language Language} to get the message from.
+     * @param code     The code of the message to get.
+     * @param args     (optional) The variables to replace in the message.
+     * @return The message in the player's language. If no message is found with the provided code, a standard 404
+     * message will be returned.
+     * @since 2.7.0
+     */
+    String getText(String language, String code, Object... args);
+
+    /**
      * Get a message from its code in the main language.
      *
      * @param code The code of the message to get.

--- a/src/main/java/com/rexcantor64/triton/api/language/LanguageManager.java
+++ b/src/main/java/com/rexcantor64/triton/api/language/LanguageManager.java
@@ -3,6 +3,7 @@ package com.rexcantor64.triton.api.language;
 import com.rexcantor64.triton.api.players.LanguagePlayer;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * This class manages all the languages and messages.
@@ -43,7 +44,7 @@ public interface LanguageManager {
      * @param args     (optional) The variables to replace in the message.
      * @return The message in the player's language. If no message is found with the provided code, a standard 404
      * message will be returned.
-     * @since 2.7.0
+     * @since 3.0.0
      */
     String getText(String language, String code, Object... args);
 
@@ -64,7 +65,7 @@ public interface LanguageManager {
      * @param player   The {@link LanguagePlayer LanguagePlayer} to get the language from. Use the
      *                 {@link com.rexcantor64.triton.api.players.PlayerManager PlayerManager} to get it.
      * @param location The location of the sign.
-     * @return The message in the player's language. If no translatable sign is found on that location, null is
+     * @return The lines in the player's language. If no translatable sign is found on that location, null is
      * returned.
      * @since 1.0.0
      */
@@ -77,11 +78,41 @@ public interface LanguageManager {
      *                     {@link com.rexcantor64.triton.api.players.PlayerManager PlayerManager} to get it.
      * @param location     The location of the sign.
      * @param defaultLines The lines of the sign before translation.
-     * @return The message in the player's language. If no translatable sign is found on that location, null is
+     * @return The lines in the player's language. If no translatable sign is found on that location, null is
      * returned.
      * @since 2.3.0
      */
     String[] getSign(LanguagePlayer player, SignLocation location, String[] defaultLines);
+
+    /**
+     * Get the 4 sign lines for a sign in a player's language, but allows for dynamic signs.
+     * This also allows for the defaultLines to only be fetched if needed, improving performance.
+     *
+     * @param player       The {@link LanguagePlayer LanguagePlayer} to get the language from. Use the
+     *                     {@link com.rexcantor64.triton.api.players.PlayerManager PlayerManager} to get it.
+     * @param location     The location of the sign.
+     * @param defaultLines A {@link java.util.function.Supplier Supplier} that resolves to the lines of the sign
+     *                     before translation.
+     * @return The lines in the player's language. If no translatable sign is found on that location, null is
+     * returned.
+     * @since 3.0.0
+     */
+    String[] getSign(LanguagePlayer player, SignLocation location, Supplier<String[]> defaultLines);
+
+    /**
+     * Get the 4 sign lines for a sign in a player's language, but allows for dynamic signs.
+     * This also allows for the defaultLines to only be fetched if needed, improving performance.
+     *
+     * @param language     The {@link Language#getName() name of the language} to use. If invalid, this will fallback
+     *                     to the main language without warning.
+     * @param location     The location of the sign.
+     * @param defaultLines A {@link java.util.function.Supplier Supplier} that resolves to the lines of the sign
+     *                     before translation.
+     * @return The lines in the player's language. If no translatable sign is found on that location, null is
+     * returned.
+     * @since 3.0.0
+     */
+    String[] getSign(String language, SignLocation location, Supplier<String[]> defaultLines);
 
     /**
      * Get a {@link Language language} by its name.

--- a/src/main/java/com/rexcantor64/triton/api/language/LanguageParser.java
+++ b/src/main/java/com/rexcantor64/triton/api/language/LanguageParser.java
@@ -1,0 +1,33 @@
+package com.rexcantor64.triton.api.language;
+
+import com.rexcantor64.triton.api.config.FeatureSyntax;
+import net.md_5.bungee.api.chat.BaseComponent;
+
+/**
+ * The class responsible by translating messages with placeholders
+ */
+public interface LanguageParser {
+
+    /**
+     * Parses Triton's placeholders in a string and returns the result
+     *
+     * @param language The {@link Language#getName() name of the language} to use. If invalid, this will fallback
+     *                 to the main language without warning.
+     * @param syntax   The {@link FeatureSyntax} that'll be used for Triton's placeholders syntax.
+     * @param input    The input {@link String}.
+     * @return The input but with Triton's placeholders replaced by the message in the provided language.
+     */
+    String parseString(String language, FeatureSyntax syntax, String input);
+
+    /**
+     * Parses Triton's placeholders in a {@link BaseComponent} array and returns the result
+     *
+     * @param language The {@link Language#getName() name of the language} to use. If invalid, this will fallback
+     *                 to the main language without warning.
+     * @param syntax   The {@link FeatureSyntax} that'll be used for Triton's placeholders syntax.
+     * @param input    The input {@link BaseComponent}.
+     * @return The input but with Triton's placeholders replaced by the message in the provided language.
+     */
+    BaseComponent[] parseComponent(String language, FeatureSyntax syntax, BaseComponent... input);
+
+}


### PR DESCRIPTION
This PR updates the API to reflect all the changes in Triton v3.

Changelog:

- New `Triton#getConfig` method that's an alias of `Triton#getConf`
- New `Triton#getLanguageParser` method
- Deprecated all scoreboard related config methods
- New `TritonConfig#getLogLevel`, `TritonConfig#getStorageType` and `TritonConfig#isPreventPlaceholdersInChat` methods to reflect new config options.
- Added more `LanguageManager#getText` and `LanguageManager#getSign` methods to reflect v3 changes and method requests
- New `LanguageParser` class with `LanguageParser#parseString` and `LanguageParser#parseComponent` methods, as requested by #107 