### PR TITLE
Fix for CVE-2021-44832

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     }
 
     compileOnly 'me.clip:placeholderapi:2.10.6'
-    compileOnly 'org.apache.logging.log4j:log4j-core:2.16.0'
+    compileOnly 'org.apache.logging.log4j:log4j-core:2.17.1'
     implementation 'org.slf4j:slf4j-nop:1.7.32'
     implementation 'com.zaxxer:HikariCP:3.4.5'
     implementation('com.tananaev:json-patch:1.1') {


### PR DESCRIPTION
updated log4j-core:2.16.0 to 2.17.1