### PR TITLE
use the same url regex pattern as bungeecord

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/utils/ComponentUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/ComponentUtils.java
@@ -16,9 +16,7 @@ import java.util.stream.Stream;
 
 public class ComponentUtils {
 
-    private static final Pattern url = Pattern.compile("^((([A-Za-z]{3,9}:(?:\\/\\/)?)(?:[-;:&=\\+\\$,\\w]+@)" +
-            "?[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\\+\\$,\\w]+@)[A-Za-z0-9.-]+)((?:\\/[\\+~%\\/.\\w-_]*)?\\??" +
-            "(?:[-\\+=&;%@.\\w_/]*)#?(?:[\\w]*))?)$");
+    private static final Pattern url = Pattern.compile("^(?:(https?)://)?([-\\w_\\.]{2,}\\.[a-z]{2,4})(/\\S*)?$");
 
     public static int encodeClickAction(ClickEvent.Action action) {
         switch (action) {


### PR DESCRIPTION
Triton is removing valid ClickEvents from TextComponents due to a faulty regex pattern.
The regex was replaced by the same one bungeecord uses.

Rel: https://discord.com/channels/395565283047374850/395566597860884480/972861561418956810
