### PR TITLE
Add MySQL connector to Velocity

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/storage/MysqlStorage.java
+++ b/core/src/main/java/com/rexcantor64/triton/storage/MysqlStorage.java
@@ -57,6 +57,7 @@ public class MysqlStorage extends Storage {
     public void load() {
         this.ipCache = new IpCache();
 
+        config.setDriverClassName("com.mysql.cj.jdbc.Driver");
         config.setJdbcUrl("jdbc:mysql://" + this.host + ":" + this.port + "/" + this.database + "?useSSL=false" +
                 "&useUnicode=yes&characterEncoding=UTF-8");
         config.setUsername(user);

--- a/triton-velocity/build.gradle
+++ b/triton-velocity/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     compileOnly 'com.velocitypowered:velocity-api:3.1.0'
     annotationProcessor 'com.velocitypowered:velocity-api:3.1.0'
 
+    // FIXME in the future change this to dynamic download and loading
+    implementation 'mysql:mysql-connector-java:8.0.30'
+
     implementation 'org.bstats:bstats-velocity:3.0.0'
 }
 


### PR DESCRIPTION
Add `mysql:mysql-connector-java` to the bundle.
However, this is not relocated, and might cause compatibility issues.
Before the final release of v4.0.0, this should be resolved.

Fixes #206 