### PR TITLE
Work around legacy section char inside Components

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/language/parser/AdventureParser.java
+++ b/core/src/main/java/com/rexcantor64/triton/language/parser/AdventureParser.java
@@ -4,6 +4,7 @@ import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.api.config.FeatureSyntax;
 import com.rexcantor64.triton.api.language.Localized;
 import com.rexcantor64.triton.api.language.MessageParser;
+import com.rexcantor64.triton.utils.ComponentUtils;
 import com.rexcantor64.triton.utils.StringUtils;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -91,6 +92,12 @@ public class AdventureParser implements MessageParser {
     @VisibleForTesting
     TranslationResult<Component> translateComponent(Component component, TranslationConfiguration configuration) {
         String plainText = componentToString(component);
+
+        if (ComponentUtils.hasLegacyFormatting(plainText)) {
+            component = ComponentUtils.unflattenLegacyFormatting(component);
+            plainText = componentToString(component);
+        }
+
         val indexes = this.getPatternIndexArray(plainText, configuration.getFeatureSyntax().getLang());
 
         if (indexes.size() == 0) {

--- a/core/src/test/java/com/rexcantor64/triton/language/parser/AdventureParserTest.java
+++ b/core/src/test/java/com/rexcantor64/triton/language/parser/AdventureParserTest.java
@@ -21,7 +21,12 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static com.rexcantor64.triton.utils.ComponentUtils.SECTION_CHAR;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AdventureParserTest {
 
@@ -611,6 +616,27 @@ public class AdventureParserTest {
         TranslationResult<Component> result = parser.translateComponent(comp, configuration);
 
         assertEquals(TranslationResult.ResultState.TO_REMOVE, result.getState());
+    }
+
+    @Test
+    public void testParseComponentWithLegacyColorCodesInsideJson() {
+        Component comp = Component.text(SECTION_CHAR + "asomething " + SECTION_CHAR + "c[lang]without.formatting[/lang]");
+
+        TranslationResult<Component> result = parser.translateComponent(comp, configuration);
+
+        Component expected = Component.text()
+                .append(
+                        Component.text()
+                                .content("something ")
+                                .color(NamedTextColor.GREEN),
+                        Component.text("This is text without formatting")
+                                .color(NamedTextColor.RED)
+                )
+                .asComponent();
+
+        assertEquals(TranslationResult.ResultState.CHANGED, result.getState());
+        assertNotNull(result.getResultRaw());
+        assertEquals(expected.compact(), result.getResultRaw().compact());
     }
 
     @Test

--- a/core/src/test/java/com/rexcantor64/triton/utils/ComponentUtilsTest.java
+++ b/core/src/test/java/com/rexcantor64/triton/utils/ComponentUtilsTest.java
@@ -8,7 +8,10 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.junit.jupiter.api.Test;
 
+import static com.rexcantor64.triton.utils.ComponentUtils.SECTION_CHAR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ComponentUtilsTest {
 
@@ -121,6 +124,77 @@ public class ComponentUtilsTest {
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i].asComponent().compact(), result.get(i).compact());
         }
+    }
+
+    @Test
+    public void testHasLegacyFormattingWithLegacyText() {
+        String input = SECTION_CHAR + "aHello World!";
+
+        assertTrue(ComponentUtils.hasLegacyFormatting(input));
+    }
+
+    @Test
+    public void testHasLegacyFormattingWithoutLegacyText() {
+        String input = "Hello World!";
+
+        assertFalse(ComponentUtils.hasLegacyFormatting(input));
+    }
+
+    @Test
+    public void testUnflattenLegacyFormattingFromSimpleComponent() {
+        Component component = Component.text("Hello " + SECTION_CHAR + "bWorld!");
+
+        Component result = ComponentUtils.unflattenLegacyFormatting(component);
+
+        Component expected = Component.text("Hello ")
+                .append(
+                        Component.text("World!").color(NamedTextColor.AQUA)
+                );
+
+        assertEquals(result.compact(), expected.compact());
+    }
+
+    @Test
+    public void testUnflattenLegacyFormattingFromNestedComponent() {
+        Component component = Component.keybind()
+                .keybind("test")
+                .append(
+                        Component.text()
+                                .content("Hello " + SECTION_CHAR + "cWorld!")
+                                .color(NamedTextColor.GREEN)
+                                .append(
+                                        Component.text()
+                                                .content(" Lorem " + SECTION_CHAR + "0Ipsum")
+                                                .color(NamedTextColor.BLUE)
+                                )
+                )
+                .asComponent();
+
+        Component result = ComponentUtils.unflattenLegacyFormatting(component);
+
+        Component expected = Component.keybind()
+                .keybind("test")
+                .append(
+                        Component.text()
+                                .content("Hello ")
+                                .color(NamedTextColor.GREEN)
+                                .append(
+                                        Component.text()
+                                                .content("World!")
+                                                .color(NamedTextColor.RED),
+                                        Component.text()
+                                                .content(" Lorem ")
+                                                .color(NamedTextColor.BLUE)
+                                                .append(
+                                                        Component.text()
+                                                                .content("Ipsum")
+                                                                .color(NamedTextColor.BLACK)
+                                                )
+                                )
+                )
+                .asComponent();
+
+        assertEquals(result.compact(), expected.compact());
     }
 
 }


### PR DESCRIPTION
Some plugins still send JSON messages with legacy formatting inside them.

Closes #254 