### PR TITLE
Add support for MC 1.19.3

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,7 +11,7 @@ test {
 }
 
 dependencies {
-    compileOnly 'org.spigotmc:spigot-api:1.19-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.19.3-R0.1-SNAPSHOT'
     compileOnly 'net.md-5:bungeecord-api:1.19-R0.1-SNAPSHOT'
     compileOnly 'net.md-5:bungeecord-proxy:1.19-R0.1-SNAPSHOT'
     compileOnly 'com.velocitypowered:velocity-api:3.1.0'

--- a/core/src/main/java/com/rexcantor64/triton/BungeeMLP.java
+++ b/core/src/main/java/com/rexcantor64/triton/BungeeMLP.java
@@ -20,6 +20,7 @@ import net.md_5.bungee.api.connection.Connection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.scheduler.ScheduledTask;
 import net.md_5.bungee.netty.PipelineUtils;
+import net.md_5.bungee.protocol.MinecraftEncoder;
 import org.bstats.bungeecord.Metrics;
 import org.bstats.charts.SingleLineChart;
 
@@ -120,9 +121,10 @@ public class BungeeMLP extends Triton {
             Object ch = NMSUtils.getDeclaredField(p, "ch");
             Method method = ch.getClass().getDeclaredMethod("getHandle");
             Channel channel = (Channel) method.invoke(ch, new Object[0]);
+            int protocolVersion = (int) NMSUtils.getDeclaredField(channel.pipeline().get(MinecraftEncoder.class), "protocolVersion");
             channel.pipeline().addAfter(PipelineUtils.PACKET_DECODER, "triton-custom-decoder", new BungeeDecoder(lp));
             channel.pipeline()
-                    .addAfter(PipelineUtils.PACKET_ENCODER, "triton-custom-encoder", new BungeeListener(lp));
+                    .addAfter(PipelineUtils.PACKET_ENCODER, "triton-custom-encoder", new BungeeListener(lp, protocolVersion));
             channel.pipeline().remove("triton-pre-login-encoder");
         } catch (Exception e) {
             getLogger().logError("[PacketInjector] Failed to inject client connection for %1", lp.getUUID());

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/EntitiesPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/EntitiesPacketHandler.java
@@ -376,6 +376,7 @@ public class EntitiesPacketHandler extends PacketHandler {
      * @param packet         ProtocolLib's packet event.
      * @param languagePlayer The language player this packet is being sent to.
      */
+    @SuppressWarnings("deprecation")
     private void handlePlayerInfo(PacketEvent packet, SpigotLanguagePlayer languagePlayer) {
         if (isEntityTypeDisabled(EntityType.PLAYER)) {
             return;
@@ -428,7 +429,7 @@ public class EntitiesPacketHandler extends PacketHandler {
                     msg.setJson(ComponentSerializer.toString(result));
                 }
             }
-            dataListNew.add(new PlayerInfoData(newGP, data.getLatency(), data.getGameMode(), msg));
+            dataListNew.add(new PlayerInfoData(data.getProfileId(), data.getLatency(), data.isListed(), data.getGameMode(), newGP, msg, data.getProfileKeyData()));
         }
         if (MinecraftVersion.FEATURE_PREVIEW_UPDATE.atOrAbove()) {
             packet.getPacket().getPlayerInfoDataLists().writeSafely(1, dataListNew);
@@ -682,7 +683,7 @@ public class EntitiesPacketHandler extends PacketHandler {
                             EnumWrappers.NativeGameMode.fromBukkit(humanEntity.getGameMode()),
                             WrappedGameProfile.fromPlayer(humanEntity),
                             WrappedChatComponent.fromText(humanEntity.getPlayerListName()),
-                            null // FIXME this is preventing secure chat from working
+                            null
                     )
             );
 

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/PacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/PacketHandler.java
@@ -2,7 +2,9 @@ package com.rexcantor64.triton.packetinterceptor.protocollib;
 
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
 import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.utility.MinecraftVersion;
 import com.rexcantor64.triton.SpigotMLP;
 import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.config.MainConfig;
@@ -37,10 +39,13 @@ public abstract class PacketHandler {
         return getMain().getLanguageParser();
     }
 
+    /**
+     * @deprecated Use {@link MinecraftVersion#atOrAbove()} instead.
+     */
+    @Deprecated
     protected int getMcVersion() {
         return Triton.get().getMcVersion();
     }
-
 
     /**
      * Wrapper for {@link com.comphenix.protocol.ProtocolManager#sendServerPacket(Player, PacketContainer, boolean)}.

--- a/core/src/main/java/com/rexcantor64/triton/utils/RegistryUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/RegistryUtils.java
@@ -5,6 +5,7 @@ import com.comphenix.protocol.wrappers.MinecraftKey;
 import lombok.SneakyThrows;
 import lombok.val;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
@@ -36,8 +37,12 @@ public class RegistryUtils {
         if (tileEntityTypeRegistry != null) return;
 
         Class<?> iRegistry = MinecraftReflection.getIRegistry();
+        Class<?> builtInRegistries = MinecraftReflection.getBuiltInRegistries();
 
-        tileEntityTypeRegistry = Arrays.stream(iRegistry.getFields())
+        // Starting on 1.19.3, registry instances are stored on BuiltInRegistries class
+        Field[] fields = builtInRegistries != null ? builtInRegistries.getFields() : iRegistry.getFields();
+
+        tileEntityTypeRegistry = Arrays.stream(fields)
                 .filter(field -> {
                     if (field.getType().equals(iRegistry)) {
                         ParameterizedType type = (ParameterizedType) field.getGenericType();


### PR DESCRIPTION
Stuff that changed under the hood and needed to be fixed:
- `PlayerInfo` packet has separated into `PlayerInfoUpdate` and `PlayerInfoRemove`
- `IRegistry` no longer has registry instances, there is a new `BuiltInRegistry` class
- The entity metadata packet no longer has a list of `DataWatcher$Item`, but a list of `DataWatcher$b` (which ProtocolLib calls DataValues)