### PR TITLE
Add <triton> MiniMessage tag for translations

### DIFF
--- a/api/src/main/java/com/rexcantor64/triton/api/language/TranslationManager.java
+++ b/api/src/main/java/com/rexcantor64/triton/api/language/TranslationManager.java
@@ -32,6 +32,13 @@ public interface TranslationManager {
      *
      * @since 4.0.0
      */
+    @NotNull Optional<String> getTextString(@NotNull Localized locale, @NotNull String key);
+
+    /**
+     * // TODO javadoc
+     *
+     * @since 4.0.0
+     */
     @NotNull Optional<Component[]> getSignComponents(@NotNull Localized locale, @NotNull SignLocation location);
 
     /**


### PR DESCRIPTION
Fixes #252

This tag, to be used as `<triton:translationKey>` might be used to build arbitrary style systems, as suggested by the issue above. It works by inserting the literal value of the translation where the tag is.

So, considering a translation of key `color.primary` with the content `<red>`.
A translation with the content `[minimsg]<triton:color.primary>hello!` will be interpreted as `[minimsg]<red>hello!`.