### PR TITLE
fix(spigot): stop registering removed packets

### DIFF
--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/packetinterceptor/EntitiesPacketHandler.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/packetinterceptor/EntitiesPacketHandler.java
@@ -847,7 +847,10 @@ public class EntitiesPacketHandler extends PacketHandler {
             // 1.19 removed this packet
             registry.put(PacketType.Play.Server.SPAWN_ENTITY_LIVING, asSync(this::handleSpawnEntityLiving));
         }
-        registry.put(PacketType.Play.Server.NAMED_ENTITY_SPAWN, asSync(this::handleNamedEntitySpawn));
+        if (!MinecraftVersion.CONFIG_PHASE_PROTOCOL_UPDATE.atOrAbove()) {
+            // 1.20.2 removed this packet
+            registry.put(PacketType.Play.Server.NAMED_ENTITY_SPAWN, asSync(this::handleNamedEntitySpawn));
+        }
         registry.put(PacketType.Play.Server.ENTITY_DESTROY, asSync(this::handleEntityDestroy));
 
         registry.put(PacketType.Play.Server.PLAYER_INFO, asSync(this::handlePlayerInfo));

--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/packetinterceptor/ProtocolLibListener.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/packetinterceptor/ProtocolLibListener.java
@@ -132,7 +132,10 @@ public class ProtocolLibListener implements PacketListener {
         if (main.getMcVersion() >= 19) {
             // New chat packets on 1.19
             packetHandlers.put(PacketType.Play.Server.SYSTEM_CHAT, asAsync(this::handleSystemChat));
-            packetHandlers.put(PacketType.Play.Server.CHAT_PREVIEW, asAsync(this::handleChatPreview));
+            if (!MinecraftVersion.FEATURE_PREVIEW_UPDATE.atOrAbove()) {
+                // Removed in 1.19.3
+                packetHandlers.put(PacketType.Play.Server.CHAT_PREVIEW, asAsync(this::handleChatPreview));
+            }
         } else {
             // In 1.19+, this packet is signed, so we cannot edit it.
             // It's sent by the player anyway, so there's nothing to translate.


### PR DESCRIPTION
ChatPreview was removed in 1.19.3.
NamedEntitySpawn was removed in 1.20.2.