### PR TITLE
chore(spigot): update ProtocolLib to 5.2.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@ allprojects {
         mavenLocal()
         mavenCentral()
         maven {
+            name 'diogotcRepositorySnapshots'
+            url 'https://repo.diogotc.com/snapshots/'
+        }
+        maven {
             url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/'
             content {
                 includeGroup 'org.bukkit'
@@ -31,10 +35,6 @@ allprojects {
         maven {
             name 'velocity'
             url 'https://nexus.velocitypowered.com/repository/maven-public/'
-        }
-        maven {
-            name 'diogotcRepositorySnapshots'
-            url 'https://repo.diogotc.com/snapshots/'
         }
     }
 }

--- a/triton-spigot/build.gradle
+++ b/triton-spigot/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compileOnly 'net.kyori:adventure-text-serializer-legacy:4.11.0'
     compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.1.2'
 
-    compileOnly 'com.comphenix.protocol:ProtocolLib:5.1.1-SNAPSHOT'
+    compileOnly 'com.comphenix.protocol:ProtocolLib:5.2.0-SNAPSHOT'
     compileOnly 'me.clip:placeholderapi:2.11.1'
 
     // Libraries available on Spigot


### PR DESCRIPTION
This adds support for MC 1.20.4.
The diogotc repository has been reordered so that ProtocolLib is pulled from there first.