### PR TITLE
fix(spigot): remove duplicate async listener for incoming packets

### DIFF
--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/packetinterceptor/ProtocolLibListener.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/packetinterceptor/ProtocolLibListener.java
@@ -835,9 +835,12 @@ public class ProtocolLibListener implements PacketListener {
     @Override
     public ListeningWhitelist getReceivingWhitelist() {
         val types = new ArrayList<PacketType>();
-        types.add(PacketType.Play.Client.SETTINGS);
-        if (MinecraftVersion.CONFIG_PHASE_PROTOCOL_UPDATE.atOrAbove()) { // MC 1.20.2
-            types.add(PacketType.Configuration.Client.CLIENT_INFORMATION);
+        if (this.allowedTypes.contains(HandlerFunction.HandlerType.SYNC)) {
+            // only listen for these packets in the sync handler
+            types.add(PacketType.Play.Client.SETTINGS);
+            if (MinecraftVersion.CONFIG_PHASE_PROTOCOL_UPDATE.atOrAbove()) { // MC 1.20.2
+                types.add(PacketType.Configuration.Client.CLIENT_INFORMATION);
+            }
         }
 
         return ListeningWhitelist.newBuilder()


### PR DESCRIPTION
Incoming packets where being handled both in a sync and an async thread.

Fixes #364