### PR TITLE
chore: upgrade adventure to 4.15.0

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,10 +13,10 @@ dependencies {
 
     // Adventure / MiniMessage
     // TODO check which of these should be compileOnly or implementation
-    compileOnly 'net.kyori:adventure-text-serializer-gson:4.11.0'
-    compileOnly 'net.kyori:adventure-text-serializer-legacy:4.11.0'
-    compileOnly 'net.kyori:adventure-text-serializer-plain:4.11.0'
-    implementation('net.kyori:adventure-text-minimessage:4.11.0') {
+    compileOnly 'net.kyori:adventure-text-serializer-gson:4.15.0'
+    compileOnly 'net.kyori:adventure-text-serializer-legacy:4.15.0'
+    compileOnly 'net.kyori:adventure-text-serializer-plain:4.15.0'
+    implementation('net.kyori:adventure-text-minimessage:4.15.0') {
         exclude group: 'net.kyori', module: 'adventure-api'
         exclude group: 'net.kyori', module: 'adventure-key'
         exclude group: 'net.kyori', module: 'adventure-text-serialize-gson'
@@ -41,8 +41,8 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 
-    testImplementation 'net.kyori:adventure-api:4.11.0'
-    testImplementation 'net.kyori:adventure-text-serializer-gson:4.11.0'
-    testImplementation 'net.kyori:adventure-text-serializer-legacy:4.11.0'
-    testImplementation 'net.kyori:adventure-text-serializer-plain:4.11.0'
+    testImplementation 'net.kyori:adventure-api:4.15.0'
+    testImplementation 'net.kyori:adventure-text-serializer-gson:4.15.0'
+    testImplementation 'net.kyori:adventure-text-serializer-legacy:4.15.0'
+    testImplementation 'net.kyori:adventure-text-serializer-plain:4.15.0'
 }

--- a/core/src/test/java/com/rexcantor64/triton/language/parser/AdventureParserTest.java
+++ b/core/src/test/java/com/rexcantor64/triton/language/parser/AdventureParserTest.java
@@ -536,8 +536,12 @@ public class AdventureParserTest {
                                                         Component.text("Rexcantor64")
                                                                 .color(NamedTextColor.LIGHT_PURPLE),
                                                         Component.text()
-                                                                .content(" ")
+                                                                .content("")
                                                                 .color(NamedTextColor.BLUE)
+                                                                .append(
+                                                                        Component.text(" ")
+                                                                                .color(NamedTextColor.LIGHT_PURPLE)
+                                                                )
                                                                 .append(
                                                                         Component.text("is a very cool guy")
                                                                                 .color(NamedTextColor.GREEN)
@@ -953,7 +957,7 @@ public class AdventureParserTest {
                         )
                         .asComponent(),
                 Component.text()
-                        .color(NamedTextColor.GREEN)
+                        .color(TextColor.color(0x123456))
                         .asComponent(),
         };
 
@@ -1056,8 +1060,8 @@ public class AdventureParserTest {
                         .content("Lorem ipsum ")
                         .color(NamedTextColor.GREEN)
                         .asComponent(),
-                Component.empty(),
-                Component.empty(),
+                Component.text().color(NamedTextColor.GREEN).asComponent(),
+                Component.text().color(NamedTextColor.GREEN).asComponent(),
                 Component.text()
                         .color(NamedTextColor.GREEN)
                         .append(
@@ -1075,8 +1079,8 @@ public class AdventureParserTest {
                                 Component.keybind("ALT")
                         )
                         .asComponent(),
-                Component.empty(),
-                Component.empty(),
+                Component.text().color(NamedTextColor.GREEN).asComponent(),
+                Component.text().color(NamedTextColor.GREEN).asComponent(),
                 Component.text()
                         .color(NamedTextColor.GREEN)
                         .append(

--- a/triton-bungeecord/build.gradle
+++ b/triton-bungeecord/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compileOnly 'net.md-5:bungeecord-api:1.20-R0.2-SNAPSHOT'
     compileOnly 'net.md-5:bungeecord-proxy:1.20-R0.2-SNAPSHOT'
 
-    compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.1.2'
+    compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.3.2'
 
     implementation 'org.bstats:bstats-bungeecord:3.0.0'
 }

--- a/triton-spigot/build.gradle
+++ b/triton-spigot/build.gradle
@@ -20,9 +20,9 @@ dependencies {
 
     compileOnly 'org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT'
 
-    compileOnly 'net.kyori:adventure-text-serializer-gson:4.11.0'
-    compileOnly 'net.kyori:adventure-text-serializer-legacy:4.11.0'
-    compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.1.2'
+    compileOnly 'net.kyori:adventure-text-serializer-gson:4.15.0'
+    compileOnly 'net.kyori:adventure-text-serializer-legacy:4.15.0'
+    compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.3.2'
 
     compileOnly 'com.comphenix.protocol:ProtocolLib:5.2.0-SNAPSHOT'
     compileOnly 'me.clip:placeholderapi:2.11.1'


### PR DESCRIPTION
There were some changes to the way components are compacted, so tests had to be changed.