### PR TITLE
fix(velocity): error when sending config to all servers on startup

### DIFF
--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/VelocityTriton.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/VelocityTriton.java
@@ -71,8 +71,9 @@ public class VelocityTriton extends Triton<VelocityLanguagePlayer, VelocityBridg
     @Override
     public void reload() {
         super.reload();
-        if (bridgeManager != null)
+        if (bridgeManager != null && bridgeChannelIdentifier != null) {
             bridgeManager.sendConfigToEveryone();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes the following error on startup:

```java
[19:14:56 ERROR] [triton]: Failed to send config and language items to other servers! Not everything might work as expected
java.lang.NullPointerException: null
        at java.base/java.util.Objects.requireNonNull(Objects.java:208) ~[?:?]
        at com.velocitypowered.proxy.server.VelocityRegisteredServer.sendPluginMessage(VelocityRegisteredServer.java:151) ~[latest.jar:3.3.0-SNAPSHOT (git-be678840-b378)]
        at com.rexcantor64.triton.velocity.bridge.VelocityBridgeManager.sendPluginMessage(VelocityBridgeManager.java:132) ~[?:?]
        at com.rexcantor64.triton.velocity.bridge.VelocityBridgeManager.sendConfigToServer(VelocityBridgeManager.java:117) ~[?:?]
        at com.rexcantor64.triton.velocity.bridge.VelocityBridgeManager.sendConfigToEveryone(VelocityBridgeManager.java:101) ~[?:?]
        at com.rexcantor64.triton.velocity.VelocityTriton.reload(VelocityTriton.java:75) ~[?:?]
        at com.rexcantor64.triton.Triton.onEnable(Triton.java:100) ~[?:?]
        at com.rexcantor64.triton.velocity.VelocityTriton.onEnable(VelocityTriton.java:47) ~[?:?]
        at com.rexcantor64.triton.velocity.plugin.VelocityPlugin.onEnable(VelocityPlugin.java:43) ~[?:?]
        at com.rexcantor64.triton.velocity.plugin.Lmbda$3.execute(Unknown Source) ~[?:?]
        at com.velocitypowered.proxy.event.UntargetedEventHandler$VoidHandler.lambda$buildHandler$0(UntargetedEventHandler.java:56) ~[latest.jar:3.3.0-SNAPSHOT (git-be678840-b378)]
        at com.velocitypowered.proxy.event.VelocityEventManager.fire(VelocityEventManager.java:598) ~[latest.jar:3.3.0-SNAPSHOT (git-be678840-b378)]
        at com.velocitypowered.proxy.event.VelocityEventManager.lambda$fire$5(VelocityEventManager.java:479) ~[latest.jar:3.3.0-SNAPSHOT (git-be678840-b378)]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:833) [?:?]

```