### PR TITLE
fix(velocity): version of component holder in disconnect login packet

### DIFF
--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/packetinterceptor/packets/DisconnectHandler.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/packetinterceptor/packets/DisconnectHandler.java
@@ -4,9 +4,13 @@ import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.api.config.FeatureSyntax;
 import com.rexcantor64.triton.api.language.MessageParser;
 import com.rexcantor64.triton.velocity.player.VelocityLanguagePlayer;
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
+import lombok.val;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -37,7 +41,16 @@ public class DisconnectHandler {
                                 player,
                                 getKickSyntax()
                         )
-                        .map(result -> new ComponentHolder(player.getProtocolVersion(), result))
+                        .map(result -> {
+                            // During the Login phase, this packet is supposed to send JSON text even on 1.20.3+ (instead of NBT data)
+                            // https://github.com/PaperMC/Velocity/blob/be678840de9c927c9e17bcea06ed7aedcea77d1e/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/DisconnectPacket.java#L81-L82
+                            val connectedPlayer = (ConnectedPlayer) player.getParent();
+                            val isLoginPhase = connectedPlayer.getConnection().getState() == StateRegistry.LOGIN;
+                            return new ComponentHolder(
+                                    isLoginPhase ? ProtocolVersion.MINECRAFT_1_20_2 : player.getProtocolVersion(),
+                                    result
+                            );
+                        })
                         .mapToObj(
                                 result -> {
                                     disconnectPacket.setReason(result);


### PR DESCRIPTION
The disconnect packet during the login phase always expects a JSON text string, even on 1.20.3 and above, contrary to all other packets that take a NBT data.

This resulted in a deserialisation error message on the client, which is fixed by this commit.