### PR TITLE
fix(spigot): incompatibility with Citizens 2.0.34-b3426

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ String pluginAuthor = project.property("pluginAuthor")
 String pluginApiVersion = project.property("pluginApiVersion")
 String pluginName = project.property("pluginName")
 
+// Plugins that also hook into ProtocolLib and therefore have to be loaded before Triton
+List conflictingPlugins = ['Citizens']
+
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'net.minecrell.plugin-yml.bukkit'
 apply plugin: 'net.minecrell.plugin-yml.bungee'
@@ -73,7 +76,7 @@ bukkit {
     apiVersion = pluginApiVersion
 
     depend = ['ProtocolLib']
-    softDepend = ['PlaceholderAPI']
+    softDepend = ['PlaceholderAPI'] + conflictingPlugins
 
     commands {
         twin {


### PR DESCRIPTION
This version of Citizens fixed a longstanding issue, meaning that Citizens now tries to overwrite the entity names using ProtocolLib with priority HIGHEST (the same as Triton).

This commit adds a delay before Triton registers its ProtocolLib listeners, ensuring they are run after Citizens'.