### PR TITLE
fix(velocity): load after 'maintenance' to force listener priority

### DIFF
--- a/triton-velocity/loader/src/main/java/com/rexcantor64/triton/loader/VelocityLoader.java
+++ b/triton-velocity/loader/src/main/java/com/rexcantor64/triton/loader/VelocityLoader.java
@@ -5,6 +5,7 @@ import com.rexcantor64.triton.loader.utils.CommonLoader;
 import com.rexcantor64.triton.loader.utils.LoaderBootstrap;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
@@ -18,7 +19,13 @@ import java.nio.file.Path;
         url = "https://triton.rexcantor64.com",
         description = "A plugin that replaces any message on your server, to the receiver's language, in real time!",
         version = "@version@",
-        authors = {"Rexcantor64"}
+        authors = {"Rexcantor64"},
+        dependencies = {
+                // List of plugins that interfere with Triton in event listeners.
+                // If Triton loads after, its listeners are fired after in events with the same priority,
+                // which is what we want since Triton benefits from having the final saying in the event.
+                @Dependency(id = "maintenance", optional = true) // https://github.com/kennytv/Maintenance
+        }
 )
 public class VelocityLoader {
     private static final String PLATFORM_JAR_NAME = "triton-velocity.jarinjar";


### PR DESCRIPTION
The 'maintenance' plugin [1] also has listener priority `LAST` for ProxyPingEvent. This means that when Triton loads before it, it registers its event handler first which means it also gets triggered first.
This is a problem because Triton cannot translate any changes made by the 'maintenance' plugin.

[1]: https://github.com/kennytv/Maintenance