### PR TITLE
fix: api not being accessible through TritonAPI

### DIFF
--- a/api/src/main/java/com/rexcantor64/triton/api/TritonAPI.java
+++ b/api/src/main/java/com/rexcantor64/triton/api/TritonAPI.java
@@ -1,5 +1,6 @@
 package com.rexcantor64.triton.api;
 
+import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -7,7 +8,9 @@ import org.jetbrains.annotations.NotNull;
  *
  * @since 1.0.0
  */
-public class TritonAPI {
+public final class TritonAPI {
+    @Internal
+    private static Triton instance;
 
     /**
      * Get the instance of the {@link Triton plugin}.
@@ -16,8 +19,21 @@ public class TritonAPI {
      * @since 1.0.0
      */
     public static @NotNull Triton getInstance() {
-        // This class gets replaced with a proper implementation in Triton's build.
-        throw new UnsupportedOperationException("Triton is not running! If you're seeing this, it is because some plugin shadowed the TritonAPI (when it should not have!).");
+        if (instance == null) {
+            throw new UnsupportedOperationException("Triton is not running (yet?)! If you're seeing this, some plugin is trying to use the Triton API before Triton has loaded.");
+        }
+        return instance;
+    }
+
+    @SuppressWarnings("unused")
+    @Internal
+    private static void register(@NotNull Triton instance) {
+        TritonAPI.instance = instance;
+    }
+
+    @Internal
+    private TritonAPI() {
+        throw new UnsupportedOperationException("This class cannot be instantiated.");
     }
 
 }

--- a/core/src/main/java/com/rexcantor64/triton/Triton.java
+++ b/core/src/main/java/com/rexcantor64/triton/Triton.java
@@ -21,6 +21,7 @@ import com.rexcantor64.triton.storage.LocalStorage;
 import com.rexcantor64.triton.storage.MysqlStorage;
 import com.rexcantor64.triton.storage.Storage;
 import com.rexcantor64.triton.utils.FileUtils;
+import com.rexcantor64.triton.utils.TritonAPIUtils;
 import com.rexcantor64.triton.web.TwinManager;
 import lombok.Getter;
 import lombok.val;
@@ -86,6 +87,9 @@ public abstract class Triton<P extends LanguagePlayer, B extends BridgeManager> 
     }
 
     protected void onEnable() {
+        instance = this;
+        TritonAPIUtils.register(instance);
+
         translationsFolder = new File(getDataFolder(), "translations");
 
         logger = loader.getTritonLogger();

--- a/core/src/main/java/com/rexcantor64/triton/api/TritonAPI.java
+++ b/core/src/main/java/com/rexcantor64/triton/api/TritonAPI.java
@@ -1,9 +1,0 @@
-package com.rexcantor64.triton.api;
-
-public class TritonAPI {
-
-    public static Triton getInstance() {
-        return com.rexcantor64.triton.Triton.get();
-    }
-
-}

--- a/core/src/main/java/com/rexcantor64/triton/utils/TritonAPIUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/TritonAPIUtils.java
@@ -1,0 +1,36 @@
+package com.rexcantor64.triton.utils;
+
+import com.rexcantor64.triton.api.Triton;
+import com.rexcantor64.triton.api.TritonAPI;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Method;
+
+/**
+ * Utility functions to easily register the {@link Triton} instance in
+ * {@link TritonAPI} for consumption by other plugins.
+ *
+ * @since 4.0.0
+ */
+public class TritonAPIUtils {
+    private static final Method REGISTER;
+
+    static {
+        try {
+            REGISTER = TritonAPI.class.getDeclaredMethod("register", Triton.class);
+            REGISTER.setAccessible(true);
+
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Failed to initialize Triton API", e);
+        }
+    }
+
+    public static void register(@NotNull Triton instance) {
+        try {
+            REGISTER.invoke(null, instance);
+        } catch (Exception e) {
+            com.rexcantor64.triton.Triton.get().getLogger().logError(e, "Failed to initialize Triton API");
+        }
+    }
+
+}

--- a/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/BungeeTriton.java
+++ b/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/BungeeTriton.java
@@ -56,7 +56,6 @@ public class BungeeTriton extends Triton<BungeeLanguagePlayer, BungeeBridgeManag
 
     @Override
     public void onEnable() {
-        instance = this;
         super.onEnable();
 
         Metrics metrics = new Metrics(getPlugin(), 5607);

--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/SpigotTriton.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/SpigotTriton.java
@@ -75,8 +75,6 @@ public class SpigotTriton extends Triton<SpigotLanguagePlayer, SpigotBridgeManag
 
     @Override
     public void onEnable() {
-        instance = this;
-
         super.onEnable();
 
         if (!this.isProtocolLibAvailable()) {

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/VelocityTriton.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/VelocityTriton.java
@@ -47,7 +47,6 @@ public class VelocityTriton extends Triton<VelocityLanguagePlayer, VelocityBridg
 
     @Override
     public void onEnable() {
-        instance = this;
         super.onEnable();
 
         // bStats


### PR DESCRIPTION
Due to #285, the TritonAPI class in the core module was no longer overshadowing the same class in the api module, effectively breaking the TritonAPI#getInstance method.

This commit works around that by saving a reference to the Triton instance in the TritonAPI class ifself.