### PR TITLE
fix(spigot): special pricing information being lost on recent MC versions

### DIFF
--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/utils/ItemStackTranslationUtils.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/utils/ItemStackTranslationUtils.java
@@ -58,7 +58,7 @@ public class ItemStackTranslationUtils {
      * @param translateBooks Whether it should translate written books
      * @return The translated item stack, which may or may not be the same as the given parameter
      */
-    @Contract("null, _, _ -> null")
+    @Contract("null, _, _ -> null; !null, _, _ -> !null")
     public static @Nullable ItemStack translateItemStack(@Nullable ItemStack item, @NotNull Localized languagePlayer, boolean translateBooks) {
         if (item == null || item.getType() == Material.AIR) {
             return item;


### PR DESCRIPTION
Migrated to ProtocolLib's converter which uses the Bukkit API. Unfortunately, versions of the Bukkit API on 1.17 and below do not include all required fields, so villager translation support for them was dropped in this commit.

Fixes #421