### PR TITLE
fix: player kicked when plugin message is too big

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/bridge/BridgeSerializer.java
+++ b/core/src/main/java/com/rexcantor64/triton/bridge/BridgeSerializer.java
@@ -74,7 +74,7 @@ public class BridgeSerializer {
         return languageOut.toByteArray();
     }
 
-    public static List<byte[]> buildTranslationData(String serverName, @NonNull byte[] languageOut) {
+    public static List<byte[]> buildTranslationData(String serverName, byte @NonNull [] languageOut) {
         List<byte[]> outList = new ArrayList<>();
         try {
 
@@ -92,10 +92,11 @@ public class BridgeSerializer {
             ByteArrayDataOutput languageItemsOut = ByteStreams.newDataOutput();
             for (val collection : Triton.get().getStorage().getCollections().values())
                 for (val item : collection.getItems()) {
-                    if (languageItemsOut.toByteArray().length > 29000) {
+                    // Max array size is 32767, leave out a buffer
+                    if (languageItemsOut.toByteArray().length > 25000) {
                         val out = ByteStreams.newDataOutput();
                         out.writeByte(ActionP2S.SEND_STORAGE_AND_CONFIG.getKey());
-                        if (outList.size() == 0) {
+                        if (outList.isEmpty()) {
                             out.writeBoolean(true);
                             out.write(languageOut);
                         } else {
@@ -172,7 +173,7 @@ public class BridgeSerializer {
                 }
             val out = ByteStreams.newDataOutput();
             out.writeByte(ActionP2S.SEND_STORAGE_AND_CONFIG.getKey());
-            val firstSend = outList.size() == 0;
+            val firstSend = outList.isEmpty();
             out.writeBoolean(firstSend);
             if (firstSend)
                 out.write(languageOut);

--- a/spigot-legacy/build.gradle
+++ b/spigot-legacy/build.gradle
@@ -6,5 +6,5 @@ group 'com.rexcantor64.triton'
 
 dependencies {
     compileOnly 'org.spigotmc:spigot-api:1.8.8-R0.1-SNAPSHOT'
-    compileOnly 'com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT'
+    compileOnly 'com.comphenix.protocol:ProtocolLib:5.0.0'
 }


### PR DESCRIPTION
This happens if there is a translation bigger than the difference of the
max size and threshold in Triton for the packet size.
The threshold was lowered to (temporarily) fix this issue.

A proper fix should be implemented in the future.