### PR TITLE
fix(velocity): don't load/relocate adventure libs in velocity

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -60,11 +60,5 @@ shadowJar {
     relocate 'com.tananaev.jsonpatch', 'com.rexcantor64.shaded.jsonpatch'
     relocate 'com.zaxxer.hikari', 'com.rexcantor64.shaded.hikari'
 
-    relocate 'net.kyori.adventure.text.minimessage', 'com.rexcantor64.triton.lib.adventure.text.minimessage'
-    relocate 'net.kyori.adventure.text.serializer.gson', 'com.rexcantor64.triton.lib.adventure.text.serializer.gson'
-    relocate 'net.kyori.adventure.text.serializer.legacy', 'com.rexcantor64.triton.lib.adventure.text.serializer.legacy'
-    relocate 'net.kyori.adventure.text.serializer.plain', 'com.rexcantor64.triton.lib.adventure.text.serializer.plain'
-    relocate 'net.kyori.adventure.text.serializer.bungeecord', 'com.rexcantor64.triton.lib.adventure.text.serializer.bungeecord'
-
     relocate 'net.byteflux.libby', 'com.rexcantor64.triton.lib.libby'
 }

--- a/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/CommonLoader.java
+++ b/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/CommonLoader.java
@@ -24,8 +24,17 @@ public class CommonLoader {
 
     public LoaderBootstrap loadPlugin() {
         List<Relocation> relocations = new ArrayList<>();
-        if (flags.contains(LoaderFlag.RELOCATE_ADVENTURE)) {
-            relocations.add(new Relocation("net/kyori/adventure", "com/rexcantor64/triton/lib/adventure"));
+        if (flags.contains(LoaderFlag.SHADE_ADVENTURE)) {
+            if (flags.contains(LoaderFlag.RELOCATE_ADVENTURE)) {
+                relocations.add(new Relocation("net/kyori/adventure", "com/rexcantor64/triton/lib/adventure"));
+            } else {
+                // relocate only specific adventure libraries (instead of everything)
+                relocations.add(new Relocation("net/kyori/adventure/text/minimessage", "com/rexcantor64/triton/lib/adventure/text/minimessage"));
+                relocations.add(new Relocation("net/kyori/adventure/text/serializer/gson", "com/rexcantor64/triton/lib/adventure/text/serializer/gson"));
+                relocations.add(new Relocation("net/kyori/adventure/text/serializer/legacy", "com/rexcantor64/triton/lib/adventure/text/serializer/legacy"));
+                relocations.add(new Relocation("net/kyori/adventure/text/serializer/plain", "com/rexcantor64/triton/lib/adventure/text/serializer/plain"));
+                relocations.add(new Relocation("net/kyori/adventure/text/serializer/bungeecord", "com/rexcantor64/triton/lib/adventure/text/serializer/bungeecord"));
+            }
         }
 
         @SuppressWarnings("resource")

--- a/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/LoaderFlag.java
+++ b/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/LoaderFlag.java
@@ -1,5 +1,6 @@
 package com.rexcantor64.triton.loader.utils;
 
 public enum LoaderFlag {
+    SHADE_ADVENTURE,
     RELOCATE_ADVENTURE,
 }

--- a/core/src/main/java/com/rexcantor64/triton/dependencies/DependencyManager.java
+++ b/core/src/main/java/com/rexcantor64/triton/dependencies/DependencyManager.java
@@ -31,17 +31,19 @@ public class DependencyManager {
         libraryManager.addRepository(Repository.DIOGOTC_MIRROR);
         libraryManager.addMavenCentral();
 
-        if (hasLoaderFlag(LoaderFlag.RELOCATE_ADVENTURE)) {
-            loadDependency(Dependency.ADVENTURE);
-            loadDependency(Dependency.ADVENTURE_KEY);
-            loadDependency(Dependency.KYORI_EXAMINATION_API);
-            loadDependency(Dependency.KYORI_EXAMINATION_STRING);
+        if (hasLoaderFlag(LoaderFlag.SHADE_ADVENTURE)) {
+            if (hasLoaderFlag(LoaderFlag.RELOCATE_ADVENTURE)) {
+                loadDependency(Dependency.ADVENTURE);
+                loadDependency(Dependency.ADVENTURE_KEY);
+                loadDependency(Dependency.KYORI_EXAMINATION_API);
+                loadDependency(Dependency.KYORI_EXAMINATION_STRING);
+            }
+            loadDependency(Dependency.KYORI_OPTION);
+            loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_GSON);
+            loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_JSON);
+            loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_LEGACY);
+            loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_PLAIN);
+            loadDependency(Dependency.ADVENTURE_MINI_MESSAGE);
         }
-        loadDependency(Dependency.KYORI_OPTION);
-        loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_GSON);
-        loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_JSON);
-        loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_LEGACY);
-        loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_PLAIN);
-        loadDependency(Dependency.ADVENTURE_MINI_MESSAGE);
     }
 }

--- a/triton-bungeecord/build.gradle
+++ b/triton-bungeecord/build.gradle
@@ -25,11 +25,5 @@ shadowJar {
 
     relocate 'org.bstats', 'com.rexcantor64.triton.metrics'
 
-    relocate 'net.kyori.adventure.text.minimessage', 'com.rexcantor64.triton.lib.adventure.text.minimessage'
-    relocate 'net.kyori.adventure.text.serializer.gson', 'com.rexcantor64.triton.lib.adventure.text.serializer.gson'
-    relocate 'net.kyori.adventure.text.serializer.legacy', 'com.rexcantor64.triton.lib.adventure.text.serializer.legacy'
-    relocate 'net.kyori.adventure.text.serializer.plain', 'com.rexcantor64.triton.lib.adventure.text.serializer.plain'
-    relocate 'net.kyori.adventure.text.serializer.bungeecord', 'com.rexcantor64.triton.lib.adventure.text.serializer.bungeecord'
-
     relocate 'net.byteflux.libby', 'com.rexcantor64.triton.lib.libby'
 }

--- a/triton-bungeecord/loader/src/main/java/com/rexcantor64/triton/loader/BungeeLoader.java
+++ b/triton-bungeecord/loader/src/main/java/com/rexcantor64/triton/loader/BungeeLoader.java
@@ -17,6 +17,7 @@ public class BungeeLoader extends Plugin {
                 .bootstrapClassName(BOOTSTRAP_CLASS)
                 .constructorType(Plugin.class)
                 .constructorValue(this)
+                .flag(LoaderFlag.SHADE_ADVENTURE)
                 .flag(LoaderFlag.RELOCATE_ADVENTURE)
                 .build()
                 .loadPlugin();

--- a/triton-spigot/build.gradle
+++ b/triton-spigot/build.gradle
@@ -45,11 +45,5 @@ shadowJar {
 
     relocate 'org.bstats', 'com.rexcantor64.triton.metrics'
 
-    relocate 'net.kyori.adventure.text.minimessage', 'com.rexcantor64.triton.lib.adventure.text.minimessage'
-    relocate 'net.kyori.adventure.text.serializer.gson', 'com.rexcantor64.triton.lib.adventure.text.serializer.gson'
-    relocate 'net.kyori.adventure.text.serializer.legacy', 'com.rexcantor64.triton.lib.adventure.text.serializer.legacy'
-    relocate 'net.kyori.adventure.text.serializer.plain', 'com.rexcantor64.triton.lib.adventure.text.serializer.plain'
-    relocate 'net.kyori.adventure.text.serializer.bungeecord', 'com.rexcantor64.triton.lib.adventure.text.serializer.bungeecord'
-
     relocate 'net.byteflux.libby', 'com.rexcantor64.triton.lib.libby'
 }

--- a/triton-spigot/loader/src/main/java/com/rexcantor64/triton/loader/SpigotLoader.java
+++ b/triton-spigot/loader/src/main/java/com/rexcantor64/triton/loader/SpigotLoader.java
@@ -17,7 +17,8 @@ public class SpigotLoader extends JavaPlugin {
                 .jarInJarName(PLATFORM_JAR_NAME)
                 .bootstrapClassName(BOOTSTRAP_CLASS)
                 .constructorType(JavaPlugin.class)
-                .constructorValue(this);
+                .constructorValue(this)
+                .flag(LoaderFlag.SHADE_ADVENTURE);
 
         if (shouldRelocateAdventure()) {
             builder.flag(LoaderFlag.RELOCATE_ADVENTURE);

--- a/triton-velocity/build.gradle
+++ b/triton-velocity/build.gradle
@@ -29,10 +29,5 @@ shadowJar {
 
     relocate 'org.bstats', 'com.rexcantor64.triton.metrics'
 
-    relocate 'net.kyori.adventure.text.minimessage', 'com.rexcantor64.triton.lib.adventure.text.minimessage'
-    relocate 'net.kyori.adventure.text.serializer.gson', 'com.rexcantor64.triton.lib.adventure.text.serializer.gson'
-    relocate 'net.kyori.adventure.text.serializer.legacy', 'com.rexcantor64.triton.lib.adventure.text.serializer.legacy'
-    relocate 'net.kyori.adventure.text.serializer.plain', 'com.rexcantor64.triton.lib.adventure.text.serializer.plain'
-
     relocate 'net.byteflux.libby', 'com.rexcantor64.triton.lib.libby'
 }


### PR DESCRIPTION
Velocity already includes adventure-bom, which contains all the libraries we need. The relocation that we were doing was causing errors due to mismatching classes.

Fixes #450