### PR TITLE
fix(velocity): @version@ placeholder not being replaced in VelocityTriton

### DIFF
--- a/triton-velocity/loader/src/main/java/com/rexcantor64/triton/loader/VelocityLoader.java
+++ b/triton-velocity/loader/src/main/java/com/rexcantor64/triton/loader/VelocityLoader.java
@@ -1,12 +1,14 @@
 package com.rexcantor64.triton.loader;
 
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import com.rexcantor64.triton.loader.utils.CommonLoader;
 import com.rexcantor64.triton.loader.utils.LoaderBootstrap;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import org.slf4j.Logger;
@@ -34,17 +36,19 @@ public class VelocityLoader {
     private final LoaderBootstrap plugin;
 
     @Inject
-    public VelocityLoader(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory) {
+    public VelocityLoader(ProxyServer server, Logger logger, @Named("triton") PluginContainer container, @DataDirectory Path dataDirectory) {
         this.plugin = CommonLoader.builder()
                 .jarInJarName(PLATFORM_JAR_NAME)
                 .bootstrapClassName(BOOTSTRAP_CLASS)
                 .constructorType(Object.class)
                 .constructorType(ProxyServer.class)
                 .constructorType(Logger.class)
+                .constructorType(PluginContainer.class)
                 .constructorType(Path.class)
                 .constructorValue(this)
                 .constructorValue(server)
                 .constructorValue(logger)
+                .constructorValue(container)
                 .constructorValue(dataDirectory)
                 .build()
                 .loadPlugin();

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/VelocityTriton.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/VelocityTriton.java
@@ -14,6 +14,7 @@ import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import com.velocitypowered.api.scheduler.ScheduledTask;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.val;
 import org.bstats.charts.SingleLineChart;
 import org.bstats.velocity.Metrics;
@@ -93,8 +94,8 @@ public class VelocityTriton extends Triton<VelocityLanguagePlayer, VelocityBridg
     }
 
     @Override
-    public String getVersion() {
-        return "@version@";
+    public @NonNull String getVersion() {
+        return getLoader().getPluginContainer().getDescription().getVersion().orElse("unknown");
     }
 
     @Override

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/plugin/VelocityPlugin.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/plugin/VelocityPlugin.java
@@ -1,5 +1,6 @@
 package com.rexcantor64.triton.velocity.plugin;
 
+import com.google.inject.name.Named;
 import com.rexcantor64.triton.dependencies.DependencyManager;
 import com.rexcantor64.triton.loader.utils.LoaderBootstrap;
 import com.rexcantor64.triton.loader.utils.LoaderFlag;
@@ -8,6 +9,7 @@ import com.rexcantor64.triton.logger.TritonLogger;
 import com.rexcantor64.triton.plugin.Platform;
 import com.rexcantor64.triton.plugin.PluginLoader;
 import com.rexcantor64.triton.velocity.VelocityTriton;
+import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import lombok.Getter;
@@ -27,6 +29,8 @@ public class VelocityPlugin implements PluginLoader, LoaderBootstrap {
     private final Object plugin;
     private final ProxyServer server;
     private final TritonLogger tritonLogger;
+    @Getter
+    private final PluginContainer pluginContainer;
     private final Path dataDirectory;
     private final Metrics.Factory metricsFactory;
     @Getter
@@ -34,10 +38,11 @@ public class VelocityPlugin implements PluginLoader, LoaderBootstrap {
     @Getter
     private final DependencyManager dependencyManager;
 
-    public VelocityPlugin(Object loader, ProxyServer server, Logger logger, @DataDirectory Path dataDirectory, Set<LoaderFlag> loaderFlags) {
+    public VelocityPlugin(Object loader, ProxyServer server, Logger logger, @Named("triton") PluginContainer container, @DataDirectory Path dataDirectory, Set<LoaderFlag> loaderFlags) {
         this.plugin = loader;
         this.server = server;
         this.tritonLogger = new SLF4JLogger(logger);
+        this.pluginContainer = container;
         this.dataDirectory = dataDirectory;
         this.loaderFlags = loaderFlags;
         this.dependencyManager = new DependencyManager(new VelocityLibraryManager<>(logger, dataDirectory, server.getPluginManager(), loader), loaderFlags);


### PR DESCRIPTION
Since this class is now inside a jar-in-jar, blossom does not replace the `@version@` placeholder.
The proper fix is to get it from the plugin container instead of having the placeholders in two different places.

Fixes #434