### PR TITLE
fix(spigot): missing jansi library for terminal translation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,4 +140,5 @@ shadowJar {
     relocate 'net.kyori.adventure.text.minimessage', 'com.rexcantor64.shaded.minimessage'
     relocate 'com.tananaev.jsonpatch', 'com.rexcantor64.shaded.jsonpatch'
     relocate 'com.zaxxer.hikari', 'com.rexcantor64.shaded.hikari'
+    relocate 'org.fusesource.jansi', 'com.rexcantor64.shaded.jansi'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -28,6 +28,9 @@ dependencies {
         exclude group: 'net.kyori', module: 'adventure-text-serialize-plain'
     }
 
+    // Paper 1.21.3+ does not have this anymore, so shade and relocate it
+    implementation 'org.fusesource.jansi:jansi:2.4.0'
+
     compileOnly 'me.clip:placeholderapi:2.11.6'
     compileOnly 'org.apache.logging.log4j:log4j-core:2.17.1'
     implementation 'org.slf4j:slf4j-nop:1.7.36'


### PR DESCRIPTION
Paper 1.21.3+ has removed jansi from the included dependencies, therefore it has to be shaded with Triton now.

Fixes #464