### PR TITLE
fix(bungee): update scoreboard team wrapper with new upstream types

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/player/BungeeLanguagePlayer.java
+++ b/core/src/main/java/com/rexcantor64/triton/player/BungeeLanguagePlayer.java
@@ -20,6 +20,7 @@ import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.protocol.NumberFormat;
 import net.md_5.bungee.protocol.packet.Chat;
 import net.md_5.bungee.protocol.packet.ScoreboardObjective.HealthDisplay;
+import net.md_5.bungee.protocol.packet.Team;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
@@ -229,8 +230,8 @@ public class BungeeLanguagePlayer implements LanguagePlayer {
         private BaseComponent suffix;
 
         // other data (has to be saved for refreshing packet)
-        private String nameTagVisibility;
-        private String collisionRule;
+        private Team.NameTagVisibility nameTagVisibility;
+        private Team.CollisionRule collisionRule;
         private int color;
         private byte options;
     }


### PR DESCRIPTION
Packet format has changed in 1.21.5, so upstream has changed the types from a String to NameTagVisibility and CollisionRule.

See https://github.com/SpigotMC/BungeeCord/commit/508c2f7ac3fba6bea35b0146bcb55497580836fd