### PR TITLE
feat: handle all velocity packets with packetevents

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
@@ -8,6 +8,7 @@ import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.packetinterceptor.handlers.ActionBarPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.ChatPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.DisconnectPacketHandler;
+import com.rexcantor64.triton.packetinterceptor.handlers.ResourcePackPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.ScoreboardPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.TabPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.TitlePacketHandler;
@@ -53,6 +54,10 @@ public class PacketEventsListener implements PacketListener {
         if (config.isKick()) {
             val disconnectHandler = new DisconnectPacketHandler(parser, config);
             updatedHandlers.put(PacketType.Play.Server.DISCONNECT, disconnectHandler::onDisconnectPacket);
+        }
+        if (config.isResourcePackPrompt()) {
+            val resourcePackHandler = new ResourcePackPacketHandler(parser, config);
+            updatedHandlers.put(PacketType.Play.Server.RESOURCE_PACK_SEND, resourcePackHandler::onResourcePackSendPacket);
         }
         if (config.isScoreboards()) {
             val scoreboardHandler = new ScoreboardPacketHandler(parser, config);

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
@@ -6,6 +6,7 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
 import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.packetinterceptor.handlers.ScoreboardPacketHandler;
+import com.rexcantor64.triton.packetinterceptor.handlers.TitlePacketHandler;
 import com.rexcantor64.triton.player.TritonLanguagePlayer;
 import lombok.val;
 
@@ -40,6 +41,14 @@ public class PacketEventsListener implements PacketListener {
             val scoreboardHandler = new ScoreboardPacketHandler(parser, config);
             updatedHandlers.put(PacketType.Play.Server.TEAMS, scoreboardHandler::onTeamsPacket);
             updatedHandlers.put(PacketType.Play.Server.SCOREBOARD_OBJECTIVE, scoreboardHandler::onObjectivePacket);
+        }
+        if (config.isTitles() || config.isActionbars()) {
+            val titleHandler = new TitlePacketHandler(parser, config);
+            updatedHandlers.put(PacketType.Play.Server.TITLE, titleHandler::onTitlePacket);
+            if (config.isTitles()) {
+                updatedHandlers.put(PacketType.Play.Server.SET_TITLE_TEXT, titleHandler::onSetTitleTextPacket);
+                updatedHandlers.put(PacketType.Play.Server.SET_TITLE_SUBTITLE, titleHandler::onSetTitleSubtitlePacket);
+            }
         }
 
         receiveHandlers = Collections.unmodifiableMap(updatedHandlers);

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
@@ -8,6 +8,7 @@ import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.packetinterceptor.handlers.ActionBarPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.ChatPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.ScoreboardPacketHandler;
+import com.rexcantor64.triton.packetinterceptor.handlers.TabPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.TitlePacketHandler;
 import com.rexcantor64.triton.player.TritonLanguagePlayer;
 import lombok.val;
@@ -52,6 +53,13 @@ public class PacketEventsListener implements PacketListener {
             val scoreboardHandler = new ScoreboardPacketHandler(parser, config);
             updatedHandlers.put(PacketType.Play.Server.TEAMS, scoreboardHandler::onTeamsPacket);
             updatedHandlers.put(PacketType.Play.Server.SCOREBOARD_OBJECTIVE, scoreboardHandler::onObjectivePacket);
+        }
+        if (config.isTab()) {
+            val tabHandler = new TabPacketHandler(parser, config);
+            updatedHandlers.put(PacketType.Play.Server.PLAYER_LIST_HEADER_AND_FOOTER, tabHandler::onPlayerListHeaderAndFooterPacket);
+            updatedHandlers.put(PacketType.Play.Server.PLAYER_INFO, tabHandler::onPlayerInfoPacket);
+            updatedHandlers.put(PacketType.Play.Server.PLAYER_INFO_UPDATE, tabHandler::onPlayerInfoUpdatePacket);
+            updatedHandlers.put(PacketType.Play.Server.PLAYER_INFO_REMOVE, tabHandler::onPlayerInfoRemovePacket);
         }
         if (config.isTitles() || config.isActionbars()) {
             val titleHandler = new TitlePacketHandler(parser, config);

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
@@ -7,6 +7,7 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
 import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.packetinterceptor.handlers.ActionBarPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.ChatPacketHandler;
+import com.rexcantor64.triton.packetinterceptor.handlers.DisconnectPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.ScoreboardPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.TabPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.TitlePacketHandler;
@@ -48,6 +49,10 @@ public class PacketEventsListener implements PacketListener {
             val chatHandler = new ChatPacketHandler(parser, config);
             updatedHandlers.put(PacketType.Play.Server.CHAT_MESSAGE, chatHandler::onChatMessagePacket);
             updatedHandlers.put(PacketType.Play.Server.SYSTEM_CHAT_MESSAGE, chatHandler::onSystemChatMessagePacket);
+        }
+        if (config.isKick()) {
+            val disconnectHandler = new DisconnectPacketHandler(parser, config);
+            updatedHandlers.put(PacketType.Play.Server.DISCONNECT, disconnectHandler::onDisconnectPacket);
         }
         if (config.isScoreboards()) {
             val scoreboardHandler = new ScoreboardPacketHandler(parser, config);

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
@@ -5,6 +5,8 @@ import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
 import com.rexcantor64.triton.Triton;
+import com.rexcantor64.triton.packetinterceptor.handlers.ActionBarPacketHandler;
+import com.rexcantor64.triton.packetinterceptor.handlers.ChatPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.ScoreboardPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.TitlePacketHandler;
 import com.rexcantor64.triton.player.TritonLanguagePlayer;
@@ -37,6 +39,15 @@ public class PacketEventsListener implements PacketListener {
         val config = Triton.get().getConfig();
         val updatedHandlers = new HashMap<PacketTypeCommon, BiConsumer<PacketSendEvent, TritonLanguagePlayer<?>>>();
 
+        if (config.isActionbars()) {
+            val actionBarHandler = new ActionBarPacketHandler(parser, config);
+            updatedHandlers.put(PacketType.Play.Server.ACTION_BAR, actionBarHandler::onActionBarPacket);
+        }
+        if (config.isChat() || config.isActionbars()) {
+            val chatHandler = new ChatPacketHandler(parser, config);
+            updatedHandlers.put(PacketType.Play.Server.CHAT_MESSAGE, chatHandler::onChatMessagePacket);
+            updatedHandlers.put(PacketType.Play.Server.SYSTEM_CHAT_MESSAGE, chatHandler::onSystemChatMessagePacket);
+        }
         if (config.isScoreboards()) {
             val scoreboardHandler = new ScoreboardPacketHandler(parser, config);
             updatedHandlers.put(PacketType.Play.Server.TEAMS, scoreboardHandler::onTeamsPacket);

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
@@ -6,6 +6,7 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
 import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.packetinterceptor.handlers.ActionBarPacketHandler;
+import com.rexcantor64.triton.packetinterceptor.handlers.BossBarPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.ChatPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.DisconnectPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.ResourcePackPacketHandler;
@@ -45,6 +46,10 @@ public class PacketEventsListener implements PacketListener {
         if (config.isActionbars()) {
             val actionBarHandler = new ActionBarPacketHandler(parser, config);
             updatedHandlers.put(PacketType.Play.Server.ACTION_BAR, actionBarHandler::onActionBarPacket);
+        }
+        if (config.isBossbars()) {
+            val bossBarHandler = new BossBarPacketHandler(parser, config);
+            updatedHandlers.put(PacketType.Play.Server.BOSS_BAR, bossBarHandler::onBossBarPacket);
         }
         if (config.isChat() || config.isActionbars()) {
             val chatHandler = new ChatPacketHandler(parser, config);

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ActionBarPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ActionBarPacketHandler.java
@@ -1,0 +1,40 @@
+package com.rexcantor64.triton.packetinterceptor.handlers;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerActionBar;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerScoreboardObjective;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTeams;
+import com.rexcantor64.triton.config.MainConfig;
+import com.rexcantor64.triton.language.parser.AdventureParser;
+import com.rexcantor64.triton.player.TritonLanguagePlayer;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+@RequiredArgsConstructor
+public class ActionBarPacketHandler {
+
+    private final @NotNull AdventureParser parser;
+    private final @NotNull MainConfig.FeatureSyntax syntax;
+
+    public ActionBarPacketHandler(@NotNull AdventureParser parser, @NotNull MainConfig config) {
+        this.parser = parser;
+        this.syntax = config.getActionbarSyntax();
+    }
+
+    public void onActionBarPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerActionBar(event);
+
+        parser.translateComponent(
+                        packet.getActionBarText(),
+                        languagePlayer,
+                        syntax
+                )
+                .ifChanged(result -> {
+                    packet.setActionBarText(result);
+                    event.markForReEncode(true);
+                })
+                .ifToRemove(() -> event.setCancelled(true));
+    }
+}

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/BossBarPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/BossBarPacketHandler.java
@@ -1,0 +1,55 @@
+package com.rexcantor64.triton.packetinterceptor.handlers;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBossBar;
+import com.rexcantor64.triton.config.MainConfig;
+import com.rexcantor64.triton.language.parser.AdventureParser;
+import com.rexcantor64.triton.player.TritonLanguagePlayer;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+@RequiredArgsConstructor
+public class BossBarPacketHandler {
+
+    private final @NotNull AdventureParser parser;
+    private final @NotNull MainConfig.FeatureSyntax syntax;
+
+    public BossBarPacketHandler(@NotNull AdventureParser parser, @NotNull MainConfig config) {
+        this.parser = parser;
+        this.syntax = config.getBossbarSyntax();
+    }
+
+    public void onBossBarPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerBossBar(event);
+
+        val uuid = packet.getUUID();
+        val action = packet.getAction();
+
+        if (action == WrapperPlayServerBossBar.Action.REMOVE) {
+            languagePlayer.getPacketEventsRefresh().discardBossBar(uuid);
+            return;
+        }
+
+        if (action != WrapperPlayServerBossBar.Action.ADD && action != WrapperPlayServerBossBar.Action.UPDATE_TITLE) {
+            return;
+        }
+
+        val originalTitle = packet.getTitle();
+
+        parser.translateComponent(
+                        originalTitle,
+                        languagePlayer,
+                        syntax
+                )
+                .ifChanged(result -> languagePlayer.getPacketEventsRefresh().saveBossBar(uuid, originalTitle))
+                .ifToRemove(() -> languagePlayer.getPacketEventsRefresh().discardBossBar(uuid))
+                .ifUnchanged(() -> languagePlayer.getPacketEventsRefresh().discardBossBar(uuid))
+                .getResultOrToRemove(Component::empty)
+                .ifPresent(result -> {
+                    packet.setTitle(result);
+                    event.markForReEncode(true);
+                });
+    }
+}

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ChatPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ChatPacketHandler.java
@@ -1,0 +1,75 @@
+package com.rexcantor64.triton.packetinterceptor.handlers;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.chat.ChatTypes;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerChatMessage;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSystemChatMessage;
+import com.rexcantor64.triton.config.MainConfig;
+import com.rexcantor64.triton.language.parser.AdventureParser;
+import com.rexcantor64.triton.player.TritonLanguagePlayer;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+@RequiredArgsConstructor
+public class ChatPacketHandler {
+
+    private final @NotNull AdventureParser parser;
+    private final @NotNull MainConfig.FeatureSyntax chatSyntax;
+    private final @NotNull MainConfig.FeatureSyntax actionbarSyntax;
+    private final boolean translateChat;
+    private final boolean translateActionbars;
+
+    public ChatPacketHandler(@NotNull AdventureParser parser, @NotNull MainConfig config) {
+        this.parser = parser;
+        this.chatSyntax = config.getChatSyntax();
+        this.actionbarSyntax = config.getActionbarSyntax();
+        this.translateChat = config.isChat();
+        this.translateActionbars = config.isActionbars();
+    }
+
+    public void onChatMessagePacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerChatMessage(event);
+        val message = packet.getMessage();
+
+        @SuppressWarnings("deprecation")
+        val isActionbar = message.getType() == ChatTypes.GAME_INFO;
+        if (!(isActionbar && translateActionbars) && !(!isActionbar && translateChat)) {
+            return;
+        }
+
+        parser.translateComponent(
+                        message.getChatContent(),
+                        languagePlayer,
+                        isActionbar ? actionbarSyntax : chatSyntax
+                )
+                .ifChanged(result -> {
+                    message.setChatContent(result);
+                    event.markForReEncode(true);
+                })
+                .ifToRemove(() -> event.setCancelled(true));
+    }
+
+    public void onSystemChatMessagePacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerSystemChatMessage(event);
+
+        @SuppressWarnings("deprecation")
+        val isActionbar = packet.getType() == ChatTypes.GAME_INFO || packet.isOverlay();
+        if (!(isActionbar && translateActionbars) && !(!isActionbar && translateChat)) {
+            return;
+        }
+
+        parser.translateComponent(
+                        packet.getMessage(),
+                        languagePlayer,
+                        isActionbar ? actionbarSyntax : chatSyntax
+                )
+                .getResultOrToRemove(Component::empty)
+                .ifPresent(result -> {
+                    packet.setMessage(result);
+                    event.markForReEncode(true);
+                });
+    }
+
+}

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/DisconnectPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/DisconnectPacketHandler.java
@@ -1,0 +1,38 @@
+package com.rexcantor64.triton.packetinterceptor.handlers;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDisconnect;
+import com.rexcantor64.triton.config.MainConfig;
+import com.rexcantor64.triton.language.parser.AdventureParser;
+import com.rexcantor64.triton.player.TritonLanguagePlayer;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+@RequiredArgsConstructor
+public class DisconnectPacketHandler {
+
+    private final @NotNull AdventureParser parser;
+    private final @NotNull MainConfig.FeatureSyntax syntax;
+
+    public DisconnectPacketHandler(@NotNull AdventureParser parser, @NotNull MainConfig config) {
+        this.parser = parser;
+        this.syntax = config.getKickSyntax();
+    }
+
+    public void onDisconnectPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerDisconnect(event);
+
+        parser.translateComponent(
+                        packet.getReason(),
+                        languagePlayer,
+                        syntax
+                )
+                .getResultOrToRemove(Component::empty)
+                .ifPresent(result -> {
+                    packet.setReason(result);
+                    event.markForReEncode(true);
+                });
+    }
+}

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ResourcePackPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ResourcePackPacketHandler.java
@@ -1,0 +1,43 @@
+package com.rexcantor64.triton.packetinterceptor.handlers;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDisconnect;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerResourcePackSend;
+import com.rexcantor64.triton.config.MainConfig;
+import com.rexcantor64.triton.language.parser.AdventureParser;
+import com.rexcantor64.triton.player.TritonLanguagePlayer;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+@RequiredArgsConstructor
+public class ResourcePackPacketHandler {
+
+    private final @NotNull AdventureParser parser;
+    private final @NotNull MainConfig.FeatureSyntax syntax;
+
+    public ResourcePackPacketHandler(@NotNull AdventureParser parser, @NotNull MainConfig config) {
+        this.parser = parser;
+        this.syntax = config.getResourcePackPromptSyntax();
+    }
+
+    public void onResourcePackSendPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerResourcePackSend(event);
+
+        if (packet.getPrompt() == null) {
+            return;
+        }
+
+        parser.translateComponent(
+                        packet.getPrompt(),
+                        languagePlayer,
+                        syntax
+                )
+                .getResultOrToRemove(Component::empty)
+                .ifPresent(result -> {
+                    packet.setPrompt(result);
+                    event.markForReEncode(true);
+                });
+    }
+}

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/TabPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/TabPacketHandler.java
@@ -1,0 +1,147 @@
+package com.rexcantor64.triton.packetinterceptor.handlers;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerInfo;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerInfoRemove;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerInfoUpdate;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerListHeaderAndFooter;
+import com.rexcantor64.triton.config.MainConfig;
+import com.rexcantor64.triton.language.parser.AdventureParser;
+import com.rexcantor64.triton.player.TritonLanguagePlayer;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class TabPacketHandler {
+
+    private final @NotNull AdventureParser parser;
+    private final @NotNull MainConfig.FeatureSyntax syntax;
+
+    public TabPacketHandler(@NotNull AdventureParser parser, @NotNull MainConfig config) {
+        this.parser = parser;
+        this.syntax = config.getTabSyntax();
+    }
+
+    public void onPlayerListHeaderAndFooterPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerPlayerListHeaderAndFooter(event);
+
+        val originalHeader = packet.getHeader();
+        val originalFooter = packet.getFooter();
+
+        // header
+        parser.translateComponent(
+                        originalHeader,
+                        languagePlayer,
+                        syntax
+                )
+                .getResultOrToRemove(Component::empty)
+                .ifPresent(result -> {
+                    packet.setHeader(result);
+                    event.markForReEncode(true);
+                });
+        // footer
+        parser.translateComponent(
+                        originalFooter,
+                        languagePlayer,
+                        syntax
+                )
+                .getResultOrToRemove(Component::empty)
+                .ifPresent(result -> {
+                    packet.setFooter(result);
+                    event.markForReEncode(true);
+                });
+
+        if (event.needsReEncode()) {
+            languagePlayer.getPacketEventsRefresh().savePlayerListHeaderFooter(originalHeader, originalFooter);
+        } else {
+            languagePlayer.getPacketEventsRefresh().discardPlayerListHeaderFooter();
+        }
+    }
+
+    public void onPlayerInfoPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerPlayerInfo(event);
+
+        val action = packet.getAction();
+
+        if (action == WrapperPlayServerPlayerInfo.Action.ADD_PLAYER || action == WrapperPlayServerPlayerInfo.Action.UPDATE_DISPLAY_NAME) {
+            for (WrapperPlayServerPlayerInfo.PlayerData entry : packet.getPlayerDataList()) {
+                val uuid = entry.getUser().getUUID();
+                val originalDisplayName = entry.getDisplayName();
+                if (originalDisplayName == null) {
+                    languagePlayer.getPacketEventsRefresh().discardPlayerInfo(uuid);
+                    continue;
+                }
+
+                parser.translateComponent(
+                                originalDisplayName,
+                                languagePlayer,
+                                syntax
+                        )
+                        .ifChanged(result -> {
+                            languagePlayer.getPacketEventsRefresh().savePlayerInfo(uuid, originalDisplayName);
+                            entry.setDisplayName(result);
+                            event.markForReEncode(true);
+                        })
+                        .ifUnchanged(() -> languagePlayer.getPacketEventsRefresh().discardPlayerInfo(uuid))
+                        .ifToRemove(() -> {
+                            languagePlayer.getPacketEventsRefresh().discardPlayerInfo(uuid);
+                            entry.setDisplayName(null);
+                            event.markForReEncode(true);
+                        });
+            }
+        }
+
+        if (action == WrapperPlayServerPlayerInfo.Action.REMOVE_PLAYER) {
+            for (WrapperPlayServerPlayerInfo.PlayerData entry : packet.getPlayerDataList()) {
+                languagePlayer.getPacketEventsRefresh().discardPlayerInfo(entry.getUser().getUUID());
+            }
+        }
+    }
+
+    public void onPlayerInfoUpdatePacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerPlayerInfoUpdate(event);
+
+        val actions = packet.getActions();
+        if (!actions.contains(WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_DISPLAY_NAME)) {
+            return;
+        }
+
+        for (WrapperPlayServerPlayerInfoUpdate.PlayerInfo entry : packet.getEntries()) {
+            val uuid = entry.getProfileId();
+            val originalDisplayName = entry.getDisplayName();
+            if (originalDisplayName == null) {
+                languagePlayer.getPacketEventsRefresh().discardPlayerInfo(uuid);
+                continue;
+            }
+
+            parser.translateComponent(
+                            originalDisplayName,
+                            languagePlayer,
+                            syntax
+                    )
+                    .ifChanged(result -> {
+                        languagePlayer.getPacketEventsRefresh().savePlayerInfo(uuid, originalDisplayName);
+                        entry.setDisplayName(result);
+                        event.markForReEncode(true);
+                    })
+                    .ifUnchanged(() -> languagePlayer.getPacketEventsRefresh().discardPlayerInfo(uuid))
+                    .ifToRemove(() -> {
+                        languagePlayer.getPacketEventsRefresh().discardPlayerInfo(uuid);
+                        entry.setDisplayName(null);
+                        event.markForReEncode(true);
+                    });
+        }
+    }
+
+    public void onPlayerInfoRemovePacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerPlayerInfoRemove(event);
+
+        for (UUID uuid : packet.getProfileIds()) {
+            languagePlayer.getPacketEventsRefresh().discardPlayerInfo(uuid);
+        }
+    }
+}

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/TitlePacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/TitlePacketHandler.java
@@ -1,0 +1,101 @@
+package com.rexcantor64.triton.packetinterceptor.handlers;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetTitleSubtitle;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetTitleText;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTitle;
+import com.rexcantor64.triton.config.MainConfig;
+import com.rexcantor64.triton.language.parser.AdventureParser;
+import com.rexcantor64.triton.player.TritonLanguagePlayer;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+@RequiredArgsConstructor
+public class TitlePacketHandler {
+
+    private final @NotNull AdventureParser parser;
+    private final @NotNull MainConfig.FeatureSyntax titleSyntax;
+    private final @NotNull MainConfig.FeatureSyntax actionbarSyntax;
+    private final boolean translateTitles;
+    private final boolean translateActionbars;
+
+    public TitlePacketHandler(@NotNull AdventureParser parser, @NotNull MainConfig config) {
+        this.parser = parser;
+        this.titleSyntax = config.getTitleSyntax();
+        this.actionbarSyntax = config.getActionbarSyntax();
+        this.translateTitles = config.isTitles();
+        this.translateActionbars = config.isActionbars();
+    }
+
+    public void onTitlePacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerTitle(event);
+
+        if (translateTitles && packet.getAction() == WrapperPlayServerTitle.TitleAction.SET_TITLE) {
+            parser.translateComponent(
+                            packet.getTitle(),
+                            languagePlayer,
+                            titleSyntax
+                    )
+                    .getResultOrToRemove(Component::empty)
+                    .ifPresent(result -> {
+                        packet.setTitle(result);
+                        event.markForReEncode(true);
+                    });
+        } else if (translateTitles && packet.getAction() == WrapperPlayServerTitle.TitleAction.SET_SUBTITLE) {
+            parser.translateComponent(
+                            packet.getSubtitle(),
+                            languagePlayer,
+                            titleSyntax
+                    )
+                    .getResultOrToRemove(Component::empty)
+                    .ifPresent(result -> {
+                        packet.setSubtitle(result);
+                        event.markForReEncode(true);
+                    });
+        } else if (translateActionbars && packet.getAction() == WrapperPlayServerTitle.TitleAction.SET_ACTION_BAR) {
+            // No idea why actionbars are included in this packet...
+            parser.translateComponent(
+                            packet.getActionBar(),
+                            languagePlayer,
+                            actionbarSyntax
+                    )
+                    .getResultOrToRemove(Component::empty)
+                    .ifPresent(result -> {
+                        packet.setActionBar(result);
+                        event.markForReEncode(true);
+                    });
+        }
+    }
+
+    public void onSetTitleTextPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerSetTitleText(event);
+
+        parser.translateComponent(
+                        packet.getTitle(),
+                        languagePlayer,
+                        titleSyntax
+                )
+                .getResultOrToRemove(Component::empty)
+                .ifPresent(result -> {
+                    packet.setTitle(result);
+                    event.markForReEncode(true);
+                });
+    }
+
+    public void onSetTitleSubtitlePacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerSetTitleSubtitle(event);
+
+        parser.translateComponent(
+                        packet.getSubtitle(),
+                        languagePlayer,
+                        titleSyntax
+                )
+                .getResultOrToRemove(Component::empty)
+                .ifPresent(result -> {
+                    packet.setSubtitle(result);
+                    event.markForReEncode(true);
+                });
+    }
+}

--- a/core/src/main/java/com/rexcantor64/triton/player/PacketEventsRefresh.java
+++ b/core/src/main/java/com/rexcantor64/triton/player/PacketEventsRefresh.java
@@ -5,6 +5,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.protocol.player.UserProfile;
 import com.github.retrooper.packetevents.protocol.score.ScoreFormat;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBossBar;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerInfo;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerInfoUpdate;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerListHeaderAndFooter;
@@ -30,12 +31,43 @@ import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class PacketEventsRefresh {
+    private final Map<UUID, Component> bossBarMap = new ConcurrentHashMap<>();
     private final Map<String, ScoreBoardTeamInfo> teamsMap = new ConcurrentHashMap<>();
     private final Map<String, ScoreboardObjective> objectivesMap = new ConcurrentHashMap<>();
     private @Nullable PacketEventsRefresh.PlayerListHeaderFooter playerListHeaderFooter;
     private final Map<UUID, Component> playerInfoMap = new ConcurrentHashMap<>();
 
     private final TritonLanguagePlayer<?> languagePlayer;
+
+    /**
+     * Stores text of boss bar for later (i.e., to refresh text when language is changed).
+     *
+     * @param uuid The UUID of the boss bar.
+     * @param text The text of the boss bar.
+     * @since 4.0.0
+     */
+    public void saveBossBar(@NotNull UUID uuid, @NotNull Component text) {
+        this.bossBarMap.put(uuid, text);
+    }
+
+    /**
+     * Forget info about the given boss bar.
+     *
+     * @param uuid The UUID of the player.
+     * @since 4.0.0
+     */
+    public void discardBossBar(@NotNull UUID uuid) {
+        this.bossBarMap.remove(uuid);
+    }
+
+    /**
+     * Forget about all boss bars.
+     *
+     * @since 4.0.0
+     */
+    public void discardAllBossBars() {
+        this.bossBarMap.clear();
+    }
 
     /**
      * Stores info of a team for later (i.e., to refresh text when language is changed).
@@ -143,6 +175,10 @@ public class PacketEventsRefresh {
         val parser = Triton.get().getMessageParser();
         val cfg = Triton.get().getConfig();
 
+        if (cfg.isBossbars()) {
+            val syntax = cfg.getBossbarSyntax();
+            updateBossBars(user, syntax, parser);
+        }
         if (cfg.isScoreboards()) {
             val syntax = cfg.getScoreboardSyntax();
             updateScoreboardTeams(user, syntax, parser);
@@ -152,6 +188,21 @@ public class PacketEventsRefresh {
             val syntax = cfg.getTabSyntax();
             updatePlayerListHeaderFooter(user, syntax, parser);
             updatePlayerList(user, syntax, parser);
+        }
+    }
+
+    private void updateBossBars(@NotNull User user, @NotNull MainConfig.FeatureSyntax syntax, @NotNull AdventureParser parser) {
+        for (val entry : bossBarMap.entrySet()) {
+            val packet = new WrapperPlayServerBossBar(entry.getKey(), WrapperPlayServerBossBar.Action.UPDATE_TITLE);
+            parser.translateComponent(
+                            entry.getValue(),
+                            languagePlayer,
+                            syntax
+                    )
+                    .ifUnchanged(() -> packet.setTitle(Component.empty())) // unreachable
+                    .getResultOrToRemove(Component::empty)
+                    .ifPresent(packet::setTitle);
+            user.sendPacketSilently(packet);
         }
     }
 

--- a/core/src/main/java/com/rexcantor64/triton/player/PacketEventsRefresh.java
+++ b/core/src/main/java/com/rexcantor64/triton/player/PacketEventsRefresh.java
@@ -1,8 +1,13 @@
 package com.rexcantor64.triton.player;
 
 import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.protocol.player.UserProfile;
 import com.github.retrooper.packetevents.protocol.score.ScoreFormat;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerInfo;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerInfoUpdate;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerListHeaderAndFooter;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerScoreboardObjective;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerScoreboardObjective.RenderType;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTeams;
@@ -17,13 +22,18 @@ import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class PacketEventsRefresh {
     private final Map<String, ScoreBoardTeamInfo> teamsMap = new ConcurrentHashMap<>();
     private final Map<String, ScoreboardObjective> objectivesMap = new ConcurrentHashMap<>();
+    private @Nullable PacketEventsRefresh.PlayerListHeaderFooter playerListHeaderFooter;
+    private final Map<UUID, Component> playerInfoMap = new ConcurrentHashMap<>();
 
     private final TritonLanguagePlayer<?> languagePlayer;
 
@@ -78,6 +88,47 @@ public class PacketEventsRefresh {
     }
 
     /**
+     * Stores info of the header/footer of the player list for later (i.e., to refresh text when language is changed).
+     *
+     * @param header The header text.
+     * @param footer The footer text.
+     * @since 4.0.0
+     */
+    public void savePlayerListHeaderFooter(@NotNull Component header, @NotNull Component footer) {
+        this.playerListHeaderFooter = new PlayerListHeaderFooter(header, footer);
+    }
+
+    /**
+     * Forget info about the header/footer of the player list.
+     *
+     * @since 4.0.0
+     */
+    public void discardPlayerListHeaderFooter() {
+        this.playerListHeaderFooter = null;
+    }
+
+    /**
+     * Stores info of the player list's entry for later (i.e., to refresh text when language is changed).
+     *
+     * @param uuid The UUID of the player.
+     * @param name The display name of the player.
+     * @since 4.0.0
+     */
+    public void savePlayerInfo(@NotNull UUID uuid, @NotNull Component name) {
+        this.playerInfoMap.put(uuid, name);
+    }
+
+    /**
+     * Forget info about the given entry in the player list.
+     *
+     * @param uuid The UUID of the player.
+     * @since 4.0.0
+     */
+    public void discardPlayerInfo(@NotNull UUID uuid) {
+        this.playerInfoMap.remove(uuid);
+    }
+
+    /**
      * Refresh all active features of a player.
      *
      * @since 4.0.0
@@ -96,6 +147,11 @@ public class PacketEventsRefresh {
             val syntax = cfg.getScoreboardSyntax();
             updateScoreboardTeams(user, syntax, parser);
             updateScoreboardObjectives(user, syntax, parser);
+        }
+        if (cfg.isTab()) {
+            val syntax = cfg.getTabSyntax();
+            updatePlayerListHeaderFooter(user, syntax, parser);
+            updatePlayerList(user, syntax, parser);
         }
     }
 
@@ -166,11 +222,86 @@ public class PacketEventsRefresh {
         }
     }
 
+    private void updatePlayerListHeaderFooter(@NotNull User user, @NotNull MainConfig.FeatureSyntax syntax, @NotNull AdventureParser parser) {
+        if (this.playerListHeaderFooter == null) {
+            return;
+        }
+
+        val packet = new WrapperPlayServerPlayerListHeaderAndFooter(
+                this.playerListHeaderFooter.getHeader(),
+                this.playerListHeaderFooter.getFooter()
+        );
+
+        parser.translateComponent(
+                        packet.getHeader(),
+                        languagePlayer,
+                        syntax
+                )
+                .getResultOrToRemove(Component::empty)
+                .ifPresent(packet::setHeader);
+        parser.translateComponent(
+                        packet.getFooter(),
+                        languagePlayer,
+                        syntax
+                )
+                .getResultOrToRemove(Component::empty)
+                .ifPresent(packet::setFooter);
+
+        user.sendPacketSilently(packet);
+    }
+
+    private void updatePlayerList(@NotNull User user, @NotNull MainConfig.FeatureSyntax syntax, @NotNull AdventureParser parser) {
+        if (user.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19_3)) {
+            val packet = new WrapperPlayServerPlayerInfoUpdate(
+                    EnumSet.of(WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_DISPLAY_NAME),
+                    this.playerInfoMap.entrySet().stream()
+                            .map(entry -> {
+                                val info = new WrapperPlayServerPlayerInfoUpdate.PlayerInfo(entry.getKey());
+                                parser.translateComponent(
+                                                entry.getValue(),
+                                                languagePlayer,
+                                                syntax
+                                        )
+                                        .getResultOrToRemove(() -> null)
+                                        .ifPresent(info::setDisplayName);
+                                return info;
+                            })
+                            .collect(Collectors.toList())
+            );
+            user.sendPacketSilently(packet);
+        } else {
+            val packet = new WrapperPlayServerPlayerInfo(
+                    WrapperPlayServerPlayerInfo.Action.UPDATE_DISPLAY_NAME,
+                    this.playerInfoMap.entrySet().stream()
+                            .map(entry -> {
+                                val info = new WrapperPlayServerPlayerInfo.PlayerData(null, new UserProfile(entry.getKey(), ""), null, 0);
+                                parser.translateComponent(
+                                                entry.getValue(),
+                                                languagePlayer,
+                                                syntax
+                                        )
+                                        .getResultOrToRemove(() -> null)
+                                        .ifPresent(info::setDisplayName);
+                                return info;
+                            })
+                            .collect(Collectors.toList())
+            );
+            user.sendPacketSilently(packet);
+        }
+    }
+
     @RequiredArgsConstructor
     @Getter
     private static class ScoreboardObjective {
         private final Component displayName;
         private final RenderType renderType;
         private final ScoreFormat scoreFormat;
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    private static class PlayerListHeaderFooter {
+        private final @NotNull Component header;
+        private final @NotNull Component footer;
     }
 }

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/listeners/VelocityListener.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/listeners/VelocityListener.java
@@ -55,6 +55,9 @@ public class VelocityListener {
             if (lp.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_20_3) > 0) {
                 // On 1.20.6 and above, the notchian client crashes if a bossbar that does not exist client-side is updated
                 lp.clearCachedBossbars();
+                if (Triton.get().getConfig().isUsePacketEvents()) {
+                    lp.getPacketEventsRefresh().discardAllBossBars();
+                }
             }
 
             if (Triton.get().getConf().isRunLanguageCommandsOnLogin()) {

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/player/VelocityLanguagePlayer.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/player/VelocityLanguagePlayer.java
@@ -140,6 +140,12 @@ public class VelocityLanguagePlayer extends TritonLanguagePlayer<Player> {
     }
 
     public void injectNettyPipeline() {
+        if (Triton.get().getConfig().isUsePacketEvents()) {
+            // PacketEvents handler covers all packets translated by Velocity,
+            // so no need to inject ourselves into netty anymore.
+            Triton.get().getLogger().logDebug("Skipped injecting into netty pipeline for player %1 because PacketEvents is in use", getUUID());
+            return;
+        }
         ConnectedPlayer connectedPlayer = (ConnectedPlayer) this.parent;
         connectedPlayer.getConnection().getChannel().pipeline()
                 .addAfter(Connections.MINECRAFT_ENCODER, "triton-custom-encoder", new VelocityNettyEncoder(this));


### PR DESCRIPTION
All packets currently being handled by Velocity can now be handled by the PacketEvents listener instead.