### PR TITLE
refactor(velocity): handle language player without player instance

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
@@ -2,6 +2,7 @@ package com.rexcantor64.triton.packetinterceptor;
 
 import com.github.retrooper.packetevents.event.PacketListener;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.event.UserDisconnectEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
 import com.rexcantor64.triton.Triton;
@@ -96,6 +97,15 @@ public class PacketEventsListener implements PacketListener {
         if (handler != null) {
             val languagePlayer = Triton.get().getPlayerManager().get(event.getUser().getUUID());
             handler.accept(event, languagePlayer);
+        }
+    }
+
+    @Override
+    public void onUserDisconnect(UserDisconnectEvent event) {
+        // force language player to be unregistered
+        val uuid = event.getUser().getUUID();
+        if (uuid != null) {
+            Triton.get().getPlayerManager().unregisterPlayer(uuid);
         }
     }
 }

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/VelocityTriton.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/VelocityTriton.java
@@ -31,7 +31,7 @@ public class VelocityTriton extends Triton<VelocityLanguagePlayer, VelocityBridg
     private ScheduledTask configRefreshTask;
 
     public VelocityTriton(PluginLoader loader) {
-        super(new PlayerManager<>(VelocityLanguagePlayer::fromUUID), new VelocityBridgeManager());
+        super(new PlayerManager<>(VelocityLanguagePlayer::new), new VelocityBridgeManager());
         super.loader = loader;
     }
 

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/bridge/VelocityBridgeManager.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/bridge/VelocityBridgeManager.java
@@ -80,9 +80,11 @@ public class VelocityBridgeManager implements BridgeManager {
     }
 
     public void sendPlayerLanguage(@NonNull VelocityLanguagePlayer lp) {
-        Triton.get().getLogger().logTrace("Sending player %1 language to server", lp);
-        val out = BridgeSerializer.buildPlayerLanguageData(lp);
-        sendPluginMessage(lp.getParent(), out);
+        lp.getPlatformPlayer().ifPresent(player -> {
+            Triton.get().getLogger().logTrace("Sending player %1 language to server", lp);
+            val out = BridgeSerializer.buildPlayerLanguageData(lp);
+            sendPluginMessage(player, out);
+        });
     }
 
     public void sendExecutableCommand(String command, @NonNull RegisteredServer server) {

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/listeners/VelocityListener.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/listeners/VelocityListener.java
@@ -69,8 +69,8 @@ public class VelocityListener {
     @Subscribe(order = PostOrder.FIRST)
     public void onPlayerLogin(LoginEvent e) {
         val player = e.getPlayer();
-        val lp = new VelocityLanguagePlayer(player);
-        VelocityTriton.asVelocity().getPlayerManager().registerPlayer(lp);
+        val lp = VelocityTriton.asVelocity().getPlayerManager().get(player.getUniqueId());
+        lp.setParent(player);
         lp.injectNettyPipeline();
     }
 

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/packetinterceptor/packets/DisconnectHandler.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/packetinterceptor/packets/DisconnectHandler.java
@@ -44,8 +44,10 @@ public class DisconnectHandler {
                         .map(result -> {
                             // During the Login phase, this packet is supposed to send JSON text even on 1.20.3+ (instead of NBT data)
                             // https://github.com/PaperMC/Velocity/blob/be678840de9c927c9e17bcea06ed7aedcea77d1e/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/DisconnectPacket.java#L81-L82
-                            val connectedPlayer = (ConnectedPlayer) player.getParent();
-                            val isLoginPhase = connectedPlayer.getConnection().getState() == StateRegistry.LOGIN;
+                            val connectedPlayer = player.getPlatformPlayer().map(p -> (ConnectedPlayer) p);
+                            val isLoginPhase = connectedPlayer
+                                    .map(p -> p.getConnection().getState() == StateRegistry.LOGIN)
+                                    .orElse(true);
                             return new ComponentHolder(
                                     isLoginPhase ? ProtocolVersion.MINECRAFT_1_20_2 : player.getProtocolVersion(),
                                     result

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/player/RefreshFeatures.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/player/RefreshFeatures.java
@@ -81,7 +81,8 @@ public class RefreshFeatures {
     }
 
     private void sendPacket(MinecraftPacket packet) {
-        ((ConnectedPlayer) player.getParent()).getConnection().write(packet);
+        player.getPlatformPlayer()
+                .ifPresent(parent -> ((ConnectedPlayer) parent).getConnection().write(packet));
     }
 
 }

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/player/VelocityLanguagePlayer.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/player/VelocityLanguagePlayer.java
@@ -19,17 +19,22 @@ import lombok.val;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class VelocityLanguagePlayer extends TritonLanguagePlayer<Player> {
-    @Getter
-    private final Player parent;
+    @NotNull
+    private final UUID uuid;
+    @Nullable
+    @Setter
+    private Player parent;
 
     private Language language;
 
@@ -45,21 +50,21 @@ public class VelocityLanguagePlayer extends TritonLanguagePlayer<Player> {
     private String clientLocale;
     private final RefreshFeatures refresher;
 
-    public VelocityLanguagePlayer(@NotNull Player parent) {
+    public VelocityLanguagePlayer(@NotNull UUID uuid) {
         super();
-        this.parent = parent;
+        Objects.requireNonNull(uuid, "cannot build VelocityLanguagePlayer from null UUID");
+        this.uuid = uuid;
         this.refresher = new RefreshFeatures(this);
         Triton.get().runAsync(this::load);
     }
 
-    public static VelocityLanguagePlayer fromUUID(UUID uuid) {
-        val player = VelocityTriton.asVelocity().getLoader().getServer().getPlayer(uuid);
-        return player.map(VelocityLanguagePlayer::new).orElse(null);
-    }
-
     @Override
     public @NotNull Optional<Player> getPlatformPlayer() {
-        return Optional.of(this.parent);
+        if (this.parent == null) {
+            return VelocityTriton.asVelocity().getLoader().getServer().getPlayer(this.uuid);
+        } else {
+            return Optional.of(this.parent);
+        }
     }
 
     public void setBossbar(UUID uuid, Component lastBossBar) {
@@ -119,14 +124,18 @@ public class VelocityLanguagePlayer extends TritonLanguagePlayer<Player> {
 
     public void setLang(Language language, boolean sendToSpigot) {
         // TODO fire Triton's API change language event
-        if (this.waitingForClientLocale && getParent() != null)
-            parent.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(Triton.get().getMessagesConfig()
-                    .getMessage("success.detected-language", language.getDisplayName())));
+        val player = getPlatformPlayer();
+        if (this.waitingForClientLocale) {
+            player.ifPresent(parent -> parent.sendMessage(
+                    LegacyComponentSerializer.legacyAmpersand().deserialize(Triton.get().getMessagesConfig()
+                            .getMessage("success.detected-language", language.getDisplayName()))));
+
+        }
         this.language = language;
         this.waitingForClientLocale = false;
 
-        if (sendToSpigot && getParent() != null) {
-            VelocityTriton.asVelocity().getBridgeManager().sendPlayerLanguage(this);
+        if (sendToSpigot) {
+            player.ifPresent(p -> VelocityTriton.asVelocity().getBridgeManager().sendPlayerLanguage(this));
         }
 
         save();
@@ -146,50 +155,59 @@ public class VelocityLanguagePlayer extends TritonLanguagePlayer<Player> {
             Triton.get().getLogger().logDebug("Skipped injecting into netty pipeline for player %1 because PacketEvents is in use", getUUID());
             return;
         }
-        ConnectedPlayer connectedPlayer = (ConnectedPlayer) this.parent;
-        connectedPlayer.getConnection().getChannel().pipeline()
-                .addAfter(Connections.MINECRAFT_ENCODER, "triton-custom-encoder", new VelocityNettyEncoder(this));
+        val player = this.getPlatformPlayer();
+        player.ifPresent(parent -> {
+            ConnectedPlayer connectedPlayer = (ConnectedPlayer) parent;
+            connectedPlayer.getConnection().getChannel().pipeline()
+                    .addAfter(Connections.MINECRAFT_ENCODER, "triton-custom-encoder", new VelocityNettyEncoder(this));
+        });
     }
 
     @Override
     public UUID getUUID() {
-        return this.parent.getUniqueId();
+        return this.uuid;
     }
 
     public @NotNull ProtocolVersion getProtocolVersion() {
-        return this.getParent().getProtocolVersion();
+        return this.getPlatformPlayer().map(Player::getProtocolVersion).orElse(ProtocolVersion.UNKNOWN);
     }
 
     private void load() {
+        val player = getPlatformPlayer();
         this.language = Triton.get().getStorage().getLanguage(this);
         if (this.clientLocale != null && this.isWaitingForClientLocale()) {
             this.waitingForClientLocale = false;
             this.language = Triton.get().getLanguageManager().getLanguageByLocaleOrDefault(this.clientLocale);
-            if (getParent() != null) {
-                getParent().sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(Triton.get().getMessagesConfig()
-                        .getMessage("success.detected-language", language.getDisplayName())));
-            }
+            player.ifPresent(parent -> parent.sendMessage(
+                    LegacyComponentSerializer.legacyAmpersand().deserialize(Triton.get().getMessagesConfig()
+                            .getMessage("success.detected-language", language.getDisplayName()))));
         }
-        if (getParent() != null) {
-            Triton.get().getStorage()
-                    .setLanguage(null, SocketUtils.getIpAddress(getParent().getRemoteAddress()), language);
-        }
+        player.ifPresent(parent -> Triton.get().getStorage()
+                .setLanguage(null, SocketUtils.getIpAddress(parent.getRemoteAddress()), language));
     }
 
     private void save() {
         Triton.get().runAsync(() -> {
-            val ip = SocketUtils.getIpAddress(getParent().getRemoteAddress());
-            Triton.get().getStorage().setLanguage(getParent().getUniqueId(), ip, language);
+            val ip = getPlatformPlayer()
+                    .map(player -> SocketUtils.getIpAddress(player.getRemoteAddress()))
+                    .orElse(null);
+            Triton.get().getStorage().setLanguage(getUUID(), ip, language);
         });
     }
 
     public void executeCommands(RegisteredServer overrideServer) {
-        val currentServer = getParent().getCurrentServer();
+        val playerOpt = getPlatformPlayer();
+        if (!playerOpt.isPresent()) {
+            return;
+        }
+        val player = playerOpt.get();
+
+        val currentServer = player.getCurrentServer();
         if (overrideServer == null && !currentServer.isPresent()) return;
         val server = overrideServer == null ? currentServer.get().getServer() : overrideServer;
         for (val cmd : ((com.rexcantor64.triton.language.Language) language).getCmds()) {
-            val cmdText = cmd.getCmd().replace("%player%", getParent().getUsername())
-                    .replace("%uuid%", getParent().getUniqueId().toString());
+            val cmdText = cmd.getCmd().replace("%player%", player.getUsername())
+                    .replace("%uuid%", player.getUniqueId().toString());
 
             if (!cmd.isUniversal() && !cmd.getServers().contains(server.getServerInfo().getName())) {
                 continue;
@@ -200,11 +218,11 @@ public class VelocityLanguagePlayer extends TritonLanguagePlayer<Player> {
             if (cmd.getType() == ExecutableCommand.Type.SERVER) {
                 VelocityTriton.asVelocity().getBridgeManager().sendExecutableCommand(cmdText, server);
             } else if (cmd.getType() == ExecutableCommand.Type.PLAYER) {
-                getParent().spoofChatInput("/" + cmdText);
+                player.spoofChatInput("/" + cmdText);
             } else if (cmd.getType() == ExecutableCommand.Type.BUNGEE) {
                 velocity.getCommandManager().executeAsync(velocity.getConsoleCommandSource(), cmdText);
             } else if (cmd.getType() == ExecutableCommand.Type.BUNGEE_PLAYER) {
-                velocity.getCommandManager().executeAsync(getParent(), cmdText);
+                velocity.getCommandManager().executeAsync(player, cmdText);
             }
         }
     }
@@ -212,8 +230,7 @@ public class VelocityLanguagePlayer extends TritonLanguagePlayer<Player> {
     @Override
     public String toString() {
         return "VelocityLanguagePlayer{" +
-                "username=" + parent.getUsername() +
-                ", uuid=" + parent.getUniqueId() +
+                "uuid=" + this.getUUID() +
                 ", language=" + Optional.ofNullable(language).map(Language::getName).orElse("null") +
                 '}';
     }


### PR DESCRIPTION
This commit makes it possible to create a VelocityLanguagePlayer from a UUID only, without using Velocity's Player instance. This is necessary for plugins like LimboAPI that do not trigger LoginEvent while in the limbo phase. For that reason, when translating via PacketEvents, Triton would attempt to create instances of the VelocityLanguagePlayer but fail due to the missing player instance. This has now been fixed by removing the assumption that the Player instance is always available.

Fixes #498