### PR TITLE
fix(spigot): incompatible adventure libs on older Paper versions

### DIFF
--- a/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/CommonLoader.java
+++ b/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/CommonLoader.java
@@ -34,6 +34,7 @@ public class CommonLoader {
         if (flags.contains(LoaderFlag.SHADE_ADVENTURE)) {
             if (flags.contains(LoaderFlag.RELOCATE_ADVENTURE)) {
                 relocations.add(new Relocation("net/kyori/adventure", "com/rexcantor64/triton/lib/adventure"));
+                relocations.add(new Relocation("net/kyori/examination", "com/rexcantor64/triton/lib/kyori/examination"));
             } else {
                 // relocate only specific adventure libraries (instead of everything)
                 relocations.add(new Relocation("net/kyori/adventure/text/minimessage", "com/rexcantor64/triton/lib/adventure/text/minimessage"));
@@ -42,6 +43,7 @@ public class CommonLoader {
                 relocations.add(new Relocation("net/kyori/adventure/text/serializer/plain", "com/rexcantor64/triton/lib/adventure/text/serializer/plain"));
                 relocations.add(new Relocation("net/kyori/adventure/text/serializer/bungeecord", "com/rexcantor64/triton/lib/adventure/text/serializer/bungeecord"));
             }
+            relocations.add(new Relocation("net/kyori/option", "com/rexcantor64/triton/lib/kyori/option"));
         }
 
         if (flags.contains(LoaderFlag.VENDOR_PACKET_EVENTS)) {

--- a/core/src/main/java/com/rexcantor64/triton/utils/ComponentUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/ComponentUtils.java
@@ -1,6 +1,8 @@
 package com.rexcantor64.triton.utils;
 
 import com.google.gson.JsonElement;
+import com.rexcantor64.triton.Triton;
+import com.rexcantor64.triton.loader.utils.LoaderFlag;
 import lombok.val;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
@@ -9,6 +11,7 @@ import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.serializer.json.JSONOptions;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.jetbrains.annotations.NotNull;
@@ -25,6 +28,7 @@ import java.util.stream.IntStream;
 public class ComponentUtils {
 
     public final static char SECTION_CHAR = '§';
+    private final static GsonComponentSerializer GSON_SERIALIZER;
     private final static LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection()
             .toBuilder()
             .hexColors()
@@ -41,6 +45,19 @@ public class ComponentUtils {
 
     private static final Pattern URL_REGEX = Pattern.compile("^(?:(https?)://)?([-\\w_.]{2,}\\.[a-z]{2,})(/\\S*)?$");
 
+    static {
+        val tritonInstance = Triton.get();
+        if (tritonInstance != null && tritonInstance.getLoader().getLoaderFlags().contains(LoaderFlag.SHADE_ADVENTURE)) {
+            // use most compatible options if we shaded adventure
+            GSON_SERIALIZER = GsonComponentSerializer.builder()
+                    .options(JSONOptions.compatibility())
+                    .build();
+        } else {
+            // if using the server's adventure, just use the default
+            GSON_SERIALIZER = GsonComponentSerializer.gson();
+        }
+    }
+
     /**
      * Deserialize a JSON string representing a {@link Component}.
      *
@@ -48,7 +65,7 @@ public class ComponentUtils {
      * @return The corresponding {@link Component}.
      */
     public static Component deserializeFromJson(@NotNull String json) {
-        return GsonComponentSerializer.gson().deserialize(json);
+        return GSON_SERIALIZER.deserialize(json);
     }
 
     /**
@@ -58,7 +75,7 @@ public class ComponentUtils {
      * @return The corresponding JSON string.
      */
     public static String serializeToJson(@NotNull Component component) {
-        return GsonComponentSerializer.gson().serialize(component);
+        return GSON_SERIALIZER.serialize(component);
     }
 
     /**
@@ -68,7 +85,7 @@ public class ComponentUtils {
      * @return The corresponding {@link Component}.
      */
     public static Component deserializeFromJsonTree(@NotNull JsonElement element) {
-        return GsonComponentSerializer.gson().deserializeFromTree(element);
+        return GSON_SERIALIZER.deserializeFromTree(element);
     }
 
     /**
@@ -78,7 +95,7 @@ public class ComponentUtils {
      * @return The corresponding {@link JsonElement}.
      */
     public static JsonElement serializeToJsonTree(@NotNull Component component) {
-        return GsonComponentSerializer.gson().serializeToTree(component);
+        return GSON_SERIALIZER.serializeToTree(component);
     }
 
     /**

--- a/triton-spigot/loader/src/main/java/com/rexcantor64/triton/loader/SpigotLoader.java
+++ b/triton-spigot/loader/src/main/java/com/rexcantor64/triton/loader/SpigotLoader.java
@@ -4,7 +4,10 @@ import com.rexcantor64.triton.loader.utils.CommonLoader;
 import com.rexcantor64.triton.loader.utils.LoaderBootstrap;
 import com.rexcantor64.triton.loader.utils.LoaderFlag;
 import lombok.val;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.lang.reflect.InvocationTargetException;
 
 public class SpigotLoader extends JavaPlugin {
     private static final String PLATFORM_JAR_NAME = "triton-spigot.jarinjar";
@@ -17,11 +20,13 @@ public class SpigotLoader extends JavaPlugin {
                 .jarInJarName(PLATFORM_JAR_NAME)
                 .bootstrapClassName(BOOTSTRAP_CLASS)
                 .constructorType(JavaPlugin.class)
-                .constructorValue(this)
-                .flag(LoaderFlag.SHADE_ADVENTURE);
+                .constructorValue(this);
 
-        if (shouldRelocateAdventure()) {
-            builder.flag(LoaderFlag.RELOCATE_ADVENTURE);
+        if (!isModernPaper()) {
+            builder.flag(LoaderFlag.SHADE_ADVENTURE);
+            if (shouldRelocateAdventure()) {
+                builder.flag(LoaderFlag.RELOCATE_ADVENTURE);
+            }
         }
 
         this.plugin = builder
@@ -30,15 +35,37 @@ public class SpigotLoader extends JavaPlugin {
                 .loadPlugin();
     }
 
-    private boolean shouldRelocateAdventure() {
-        // TODO manual override
-
+    private boolean isModernPaper() {
         try {
-            // Method only available on adventure 4.18.0+
-            // Required for minimessage to work
-            // We have to check the method because other plugins might add the ShadowColor class even though it's not used
-            Class<?> styleClass = Class.forName("net.kyori.adventure.text.format.StyleGetter");
-            styleClass.getDeclaredMethod("shadowColor");
+            val server = Bukkit.getServer();
+            // this method is only available on Paper (and forks)
+            val method = server.getClass().getMethod("getMinecraftVersion");
+            String version = method.invoke(server).toString();
+
+            val parts = version.split("\\.");
+            val major = Integer.parseInt(parts[0]);
+            val minor = Integer.parseInt(parts[1]);
+            val patch = Integer.parseInt(parts[2]);
+
+            // Ensure at least Paper 1.21.4 (adventure 4.18, shadow color introduced)
+            val wantedMajor = 1;
+            val wantedMinor = 21;
+            val wantedPatch = 4;
+            return major > wantedMajor
+                    || (major == wantedMajor && minor > wantedMinor)
+                    || (major == wantedMajor && minor == wantedMinor && patch >= wantedPatch);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException |
+                 IndexOutOfBoundsException | NumberFormatException ignore) {
+            // Paper is not present or an outdated version is present
+            return false;
+        }
+    }
+
+    private boolean shouldRelocateAdventure() {
+        try {
+            // Method only available on adventure 4.22.0+
+            Class<?> clickEventClass = Class.forName("net.kyori.adventure.text.event.ClickEvent");
+            clickEventClass.getMethod("payload");
 
             // A modern version of adventure is already present
             return false;


### PR DESCRIPTION
On Paper versions with Adventure 4.21 and below, the plugin was no longer able to translate anything due to a version mismatch between adventure and the various serializers.
This commit bumps the required server adventure version when shading, but also introduces skipping shading all adventure libraries on Paper 1.21.4 and above.