### PR TITLE
fix(spigot): hover and click events not working on 1.21.5+

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/BungeeMLP.java
+++ b/core/src/main/java/com/rexcantor64/triton/BungeeMLP.java
@@ -12,6 +12,7 @@ import com.rexcantor64.triton.storage.LocalStorage;
 import com.rexcantor64.triton.terminal.BungeeTerminalManager;
 import com.rexcantor64.triton.terminal.Log4jInjector;
 import com.rexcantor64.triton.utils.NMSUtils;
+import com.rexcantor64.triton.utils.VersionedComponentUtils;
 import io.netty.channel.Channel;
 import lombok.Getter;
 import lombok.val;
@@ -19,6 +20,7 @@ import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.Connection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.scheduler.ScheduledTask;
+import net.md_5.bungee.chat.VersionedComponentSerializer;
 import net.md_5.bungee.netty.PipelineUtils;
 import org.bstats.bungeecord.Metrics;
 import org.bstats.charts.SingleLineChart;
@@ -33,6 +35,8 @@ public class BungeeMLP extends Triton {
     @Getter
     private BungeeBridgeManager bridgeManager;
     private ScheduledTask configRefreshTask;
+    @Getter
+    private VersionedComponentUtils componentSerializer;
 
     public BungeeMLP(PluginLoader loader) {
         super.loader = loader;
@@ -46,6 +50,9 @@ public class BungeeMLP extends Triton {
     public void onEnable() {
         instance = this;
         super.onEnable();
+
+        // noinspection UnstableApiUsage,deprecation
+        componentSerializer = new VersionedComponentUtils(VersionedComponentSerializer.getDefault());
 
         Metrics metrics = new Metrics(getLoader(), 5607);
         metrics.addCustomChart(new SingleLineChart("active_placeholders",

--- a/core/src/main/java/com/rexcantor64/triton/SpigotMLP.java
+++ b/core/src/main/java/com/rexcantor64/triton/SpigotMLP.java
@@ -18,12 +18,15 @@ import com.rexcantor64.triton.plugin.PluginLoader;
 import com.rexcantor64.triton.plugin.SpigotPlugin;
 import com.rexcantor64.triton.terminal.Log4jInjector;
 import com.rexcantor64.triton.utils.NMSUtils;
+import com.rexcantor64.triton.utils.VersionedComponentUtils;
 import com.rexcantor64.triton.wrappers.MaterialWrapperManager;
 import com.rexcantor64.triton.wrappers.items.ItemStackParser;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.val;
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.chat.ChatVersion;
+import net.md_5.bungee.chat.VersionedComponentSerializer;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SingleLineChart;
 import org.bukkit.Bukkit;
@@ -49,6 +52,8 @@ public class SpigotMLP extends Triton {
     @Getter
     private boolean papiEnabled = false;
     private int refreshTaskId = -1;
+    @Getter
+    private VersionedComponentUtils componentSerializer;
 
     public SpigotMLP(PluginLoader loader) {
         super.loader = loader;
@@ -69,6 +74,8 @@ public class SpigotMLP extends Triton {
             Bukkit.getPluginManager().disablePlugin(getLoader());
             return;
         }
+
+        setupVersionedComponentSerializer();
 
         Metrics metrics = new Metrics(getLoader(), 5606);
         metrics.addCustomChart(new SingleLineChart("active_placeholders",
@@ -146,6 +153,15 @@ public class SpigotMLP extends Triton {
         commandMap.register("triton", command);
 
         return command;
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    private void setupVersionedComponentSerializer() {
+        if (MinecraftVersion.v1_21_5.atOrAbove()) {
+            componentSerializer = new VersionedComponentUtils(VersionedComponentSerializer.forVersion(ChatVersion.V1_21_5));
+        } else {
+            componentSerializer = new VersionedComponentUtils(VersionedComponentSerializer.forVersion(ChatVersion.V1_16));
+        }
     }
 
     @Override

--- a/core/src/main/java/com/rexcantor64/triton/Triton.java
+++ b/core/src/main/java/com/rexcantor64/triton/Triton.java
@@ -17,6 +17,7 @@ import com.rexcantor64.triton.storage.LocalStorage;
 import com.rexcantor64.triton.storage.MysqlStorage;
 import com.rexcantor64.triton.storage.Storage;
 import com.rexcantor64.triton.utils.FileUtils;
+import com.rexcantor64.triton.utils.VersionedComponentUtils;
 import com.rexcantor64.triton.web.TwinManager;
 import lombok.Getter;
 import lombok.val;
@@ -168,4 +169,6 @@ public abstract class Triton implements com.rexcantor64.triton.api.Triton {
     }
 
     public abstract UUID getPlayerUUIDFromString(String input);
+
+    public abstract VersionedComponentUtils getComponentSerializer();
 }

--- a/core/src/main/java/com/rexcantor64/triton/VelocityMLP.java
+++ b/core/src/main/java/com/rexcantor64/triton/VelocityMLP.java
@@ -6,6 +6,7 @@ import com.rexcantor64.triton.listeners.VelocityListener;
 import com.rexcantor64.triton.plugin.PluginLoader;
 import com.rexcantor64.triton.plugin.VelocityPlugin;
 import com.rexcantor64.triton.storage.LocalStorage;
+import com.rexcantor64.triton.utils.VersionedComponentUtils;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
@@ -99,5 +100,10 @@ public class VelocityMLP extends Triton {
         } catch (IllegalArgumentException e) {
             return null;
         }
+    }
+
+    @Override
+    public VersionedComponentUtils getComponentSerializer() {
+        return null; // velocity doesn't have the md5 chat library
     }
 }

--- a/core/src/main/java/com/rexcantor64/triton/language/LanguageParser.java
+++ b/core/src/main/java/com/rexcantor64/triton/language/LanguageParser.java
@@ -20,7 +20,6 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -177,7 +176,7 @@ public class LanguageParser implements com.rexcantor64.triton.api.language.Langu
     }
 
     public BaseComponent[] parseComponent(Localized language, FeatureSyntax syntax, BaseComponent... text) {
-        text = ComponentSerializer.parse(ComponentSerializer.toString(text));
+        text = Triton.get().getComponentSerializer().reparse(text);
         text = removeTritonLinks(text).toArray(new BaseComponent[0]);
         val advancedComponent = parseAdvancedComponent(language, syntax, AdvancedComponent.fromBaseComponent(text));
 
@@ -297,7 +296,7 @@ public class LanguageParser implements com.rexcantor64.triton.api.language.Langu
         if (translatedResult.startsWith("[triton_json]")) {
             val jsonInput = translatedResult.substring(13);
             try {
-                componentResult = ComponentSerializer.parse(jsonInput);
+                componentResult = Triton.get().getComponentSerializer().parse(jsonInput);
             } catch (JsonParseException e) {
                 Triton.get().getLogger()
                         .logError(e, "Failed to parse JSON translation: %1", jsonInput);
@@ -308,7 +307,7 @@ public class LanguageParser implements com.rexcantor64.triton.api.language.Langu
             try {
                 val textComponent = MiniMessage.miniMessage().deserialize(mmInput);
                 val jsonSerialized = GsonComponentSerializer.gson().serialize(textComponent);
-                componentResult = ComponentSerializer.parse(jsonSerialized);
+                componentResult = Triton.get().getComponentSerializer().parse(jsonSerialized);
             } catch (JsonParseException | NullPointerException e) {
                 Triton.get().getLogger()
                         .logError(e, "Failed to parse Mini Message translation: %1", mmInput);

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/ProtocolLibListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/ProtocolLibListener.java
@@ -35,6 +35,7 @@ import com.rexcantor64.triton.player.SpigotLanguagePlayer;
 import com.rexcantor64.triton.utils.ComponentUtils;
 import com.rexcantor64.triton.utils.ItemStackTranslationUtils;
 import com.rexcantor64.triton.utils.NMSUtils;
+import com.rexcantor64.triton.utils.VersionedComponentUtils;
 import com.rexcantor64.triton.wrappers.AdventureComponentWrapper;
 import com.rexcantor64.triton.wrappers.WrappedClientConfiguration;
 import com.rexcantor64.triton.wrappers.WrappedPlayerChatMessage;
@@ -42,7 +43,6 @@ import lombok.Getter;
 import lombok.val;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -84,6 +84,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
     private final SignPacketHandler signPacketHandler = new SignPacketHandler();
 
     private final SpigotMLP main;
+    private final VersionedComponentUtils componentSerializer;
     private final List<HandlerFunction.HandlerType> allowedTypes;
     private final Map<PacketType, HandlerFunction> packetHandlers = new HashMap<>();
     private final AtomicBoolean firstRun = new AtomicBoolean(true);
@@ -95,6 +96,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
 
     public ProtocolLibListener(SpigotMLP main, HandlerFunction.HandlerType... allowedTypes) {
         this.main = main;
+        this.componentSerializer = main.getComponentSerializer();
         this.allowedTypes = Arrays.asList(allowedTypes);
         ADVENTURE_COMPONENT_CLASS = NMSUtils.getClassOrNull("net.kyori.adventure.text.Component");
         if (MinecraftVersion.EXPLORATION_UPDATE.atOrAbove()) { // 1.11+
@@ -260,7 +262,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
             if (playerChatMessage != null) {
                 Optional<WrappedChatComponent> msg = playerChatMessage.getMessage();
                 if (msg.isPresent()) {
-                    result = ComponentSerializer.parse(msg.get().getJson());
+                    result = componentSerializer.parse(msg.get().getJson());
                 }
             }
         } else if (adventureModifier != null && adventureModifier.readSafely(0) != null) {
@@ -271,7 +273,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
             result = baseComponentModifier.readSafely(0);
         } else {
             val msg = chatModifier.readSafely(0);
-            if (msg != null) result = ComponentSerializer.parse(msg.getJson());
+            if (msg != null) result = componentSerializer.parse(msg.getJson());
         }
 
         // Something went wrong while getting data from the packet, or the packet is empty...?
@@ -291,10 +293,10 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
 
         if (MinecraftVersion.FEATURE_PREVIEW_UPDATE.atOrAbove()) { // MC 1.19.3+
             // While chat is signed, we can still mess around with formatting and prefixes
-            chatModifier.writeSafely(0, WrappedChatComponent.fromJson(ComponentSerializer.toString(result)));
+            chatModifier.writeSafely(0, WrappedChatComponent.fromJson(componentSerializer.toString(result)));
         } else if (hasPlayerChatMessageRecord) { // MC 1.19-1.19.2
             // While chat is signed, we can still mess around with formatting and prefixes
-            playerChatModifier.readSafely(0).setMessage(Optional.of(WrappedChatComponent.fromJson(ComponentSerializer.toString(result))));
+            playerChatModifier.readSafely(0).setMessage(Optional.of(WrappedChatComponent.fromJson(componentSerializer.toString(result))));
         } else if (ab && !MinecraftVersion.EXPLORATION_UPDATE.atOrAbove()) {
             // The Notchian client does not support true JSON messages on actionbars
             // on 1.10 and below. Therefore, we must convert to a legacy string inside
@@ -334,7 +336,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
             adventureModifier.writeSafely(0, null);
         } else if (chatModifier.readSafely(0) != null) {
             try {
-                result = ComponentSerializer.parse(chatModifier.readSafely(0).getJson());
+                result = componentSerializer.parse(chatModifier.readSafely(0).getJson());
             } catch (JsonSyntaxException ignore) {
                 // The md_5 chat library can't handle some messages of 1.20.4
                 // https://github.com/SpigotMC/BungeeCord/issues/3578
@@ -343,7 +345,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
         } else {
             val msgJson = stringModifier.readSafely(0);
             if (msgJson != null) {
-                result = ComponentSerializer.parse(msgJson);
+                result = componentSerializer.parse(msgJson);
             }
         }
 
@@ -363,9 +365,9 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
         }
 
         if (chatModifier.size() > 0) {
-            chatModifier.writeSafely(0, WrappedChatComponent.fromJson(ComponentSerializer.toString(result)));
+            chatModifier.writeSafely(0, WrappedChatComponent.fromJson(componentSerializer.toString(result)));
         } else {
-            stringModifier.writeSafely(0, ComponentSerializer.toString(result));
+            stringModifier.writeSafely(0, componentSerializer.toString(result));
         }
     }
 
@@ -393,7 +395,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
         } else {
             val msg = chatComponentsModifier.readSafely(0);
             if (msg != null) {
-                result = ComponentSerializer.parse(msg.getJson());
+                result = componentSerializer.parse(msg.getJson());
             }
         }
 
@@ -413,7 +415,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
             return;
         }
 
-        chatComponentsModifier.writeSafely(0, WrappedChatComponent.fromJson(ComponentSerializer.toString(result)));
+        chatComponentsModifier.writeSafely(0, WrappedChatComponent.fromJson(componentSerializer.toString(result)));
     }
 
     /**
@@ -430,7 +432,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
 
         val chatModifier = packet.getPacket().getChatComponents();
 
-        BaseComponent[] result = ComponentSerializer.parse(chatModifier.readSafely(0).getJson());
+        BaseComponent[] result = componentSerializer.parse(chatModifier.readSafely(0).getJson());
 
         // Translate the message
         result = main.getLanguageParser().parseComponent(
@@ -445,7 +447,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
             return;
         }
 
-        chatModifier.writeSafely(0, WrappedChatComponent.fromJson(ComponentSerializer.toString(result)));
+        chatModifier.writeSafely(0, WrappedChatComponent.fromJson(componentSerializer.toString(result)));
     }
 
     private void handleActionbar(PacketEvent packet, SpigotLanguagePlayer languagePlayer) {
@@ -467,7 +469,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
             baseComponentModifier.writeSafely(0, null);
         } else {
             val msg = packet.getPacket().getChatComponents().readSafely(0);
-            if (msg != null) result = ComponentSerializer.parse(msg.getJson());
+            if (msg != null) result = componentSerializer.parse(msg.getJson());
         }
 
         // Something went wrong while getting data from the packet, or the packet is empty...?
@@ -486,7 +488,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
         }
 
         // Flatten action bar's json
-        packet.getPacket().getChatComponents().writeSafely(0, WrappedChatComponent.fromJson(ComponentSerializer.toString(result)));
+        packet.getPacket().getChatComponents().writeSafely(0, WrappedChatComponent.fromJson(componentSerializer.toString(result)));
     }
 
     private void handleTitle(PacketEvent packet, SpigotLanguagePlayer languagePlayer) {
@@ -495,12 +497,12 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
         WrappedChatComponent msg = packet.getPacket().getChatComponents().readSafely(0);
         if (msg == null) return;
         BaseComponent[] result = main.getLanguageParser().parseComponent(languagePlayer,
-                main.getConf().getTitleSyntax(), ComponentSerializer.parse(msg.getJson()));
+                main.getConf().getTitleSyntax(), componentSerializer.parse(msg.getJson()));
         if (result == null) {
             packet.setCancelled(true);
             return;
         }
-        msg.setJson(ComponentSerializer.toString(result));
+        msg.setJson(componentSerializer.toString(result));
         packet.getPacket().getChatComponents().writeSafely(0, msg);
     }
 
@@ -537,7 +539,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
         }
 
         BaseComponent[] resultHeader = main.getLanguageParser().parseComponent(languagePlayer,
-                main.getConf().getTabSyntax(), ComponentSerializer.parse(headerJson));
+                main.getConf().getTabSyntax(), componentSerializer.parse(headerJson));
         if (resultHeader == null)
             resultHeader = new BaseComponent[]{new TextComponent("")};
         else if (resultHeader.length == 1 && resultHeader[0] instanceof TextComponent) {
@@ -547,14 +549,14 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
             if (textComp.getText().length() == 0 && !headerJson.equals("{\"text\":\"\"}"))
                 textComp.setText("§0§1§2§r");
         }
-        header = WrappedChatComponent.fromJson(ComponentSerializer.toString(resultHeader));
+        header = WrappedChatComponent.fromJson(componentSerializer.toString(resultHeader));
         packet.getPacket().getChatComponents().writeSafely(0, header);
 
         BaseComponent[] resultFooter = main.getLanguageParser().parseComponent(languagePlayer,
-                main.getConf().getTabSyntax(), ComponentSerializer.parse(footerJson));
+                main.getConf().getTabSyntax(), componentSerializer.parse(footerJson));
         if (resultFooter == null)
             resultFooter = new BaseComponent[]{new TextComponent("")};
-        footer = WrappedChatComponent.fromJson(ComponentSerializer.toString(resultFooter));
+        footer = WrappedChatComponent.fromJson(componentSerializer.toString(resultFooter));
         packet.getPacket().getChatComponents().writeSafely(1, footer);
         languagePlayer.setLastTabHeader(headerJson);
         languagePlayer.setLastTabFooter(footerJson);
@@ -565,14 +567,14 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
 
         WrappedChatComponent msg = packet.getPacket().getChatComponents().readSafely(0);
         BaseComponent[] result = main.getLanguageParser()
-                .parseComponent(languagePlayer, main.getConf().getGuiSyntax(), ComponentSerializer
+                .parseComponent(languagePlayer, main.getConf().getGuiSyntax(), componentSerializer
                         .parse(msg.getJson()));
         if (result == null)
             result = new BaseComponent[]{new TextComponent("")};
         if (MinecraftVersion.NETHER_UPDATE.atOrAbove()) { // 1.16+
-            msg.setJson(ComponentSerializer.toString(result));
+            msg.setJson(componentSerializer.toString(result));
         } else {
-            msg.setJson(ComponentSerializer.toString(ComponentUtils.mergeComponents(result)));
+            msg.setJson(componentSerializer.toString(ComponentUtils.mergeComponents(result)));
         }
         packet.getPacket().getChatComponents().writeSafely(0, msg);
     }
@@ -582,10 +584,10 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
 
         WrappedChatComponent msg = packet.getPacket().getChatComponents().readSafely(0);
         BaseComponent[] result = main.getLanguageParser().parseComponent(languagePlayer,
-                main.getConf().getKickSyntax(), ComponentSerializer.parse(msg.getJson()));
+                main.getConf().getKickSyntax(), componentSerializer.parse(msg.getJson()));
         if (result == null)
             result = new BaseComponent[]{new TextComponent("")};
-        msg.setJson(ComponentSerializer.toString(result));
+        msg.setJson(componentSerializer.toString(result));
         packet.getPacket().getChatComponents().writeSafely(0, msg);
     }
 
@@ -713,10 +715,10 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
 
         for (WrappedChatComponent component : Arrays.asList(displayName, prefix, suffix)) {
             BaseComponent[] result = main.getLanguageParser()
-                    .parseComponent(languagePlayer, main.getConf().getScoreboardSyntax(), ComponentSerializer
+                    .parseComponent(languagePlayer, main.getConf().getScoreboardSyntax(), componentSerializer
                             .parse(component.getJson()));
             if (result == null) result = new BaseComponent[]{new TextComponent("")};
-            component.setJson(ComponentSerializer.toString(result));
+            component.setJson(componentSerializer.toString(result));
         }
 
         if (MinecraftVersion.CAVES_CLIFFS_1.atOrAbove()) { // 1.17+
@@ -779,10 +781,10 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
         languagePlayer.setScoreboardObjective(objectiveName, displayName.getJson(), renderType, numberFormat);
 
         BaseComponent[] result = main.getLanguageParser()
-                .parseComponent(languagePlayer, main.getConf().getScoreboardSyntax(), ComponentSerializer
+                .parseComponent(languagePlayer, main.getConf().getScoreboardSyntax(), componentSerializer
                         .parse(displayName.getJson()));
         if (result == null) result = new BaseComponent[]{new TextComponent("")};
-        displayName.setJson(ComponentSerializer.toString(result));
+        displayName.setJson(componentSerializer.toString(result));
         packet.getPacket().getChatComponents().writeSafely(0, displayName);
     }
 
@@ -799,12 +801,12 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
         BaseComponent[] result = main.getLanguageParser().parseComponent(
                 languagePlayer,
                 main.getConf().getDeathScreenSyntax(),
-                ComponentSerializer.parse(component.getJson())
+                componentSerializer.parse(component.getJson())
         );
         if (result == null) {
             result = new BaseComponent[]{new TextComponent("")};
         }
-        component.setJson(ComponentSerializer.toString(result));
+        component.setJson(componentSerializer.toString(result));
 
         packet.getPacket().getChatComponents().writeSafely(0, component);
     }
@@ -1009,7 +1011,7 @@ public class ProtocolLibListener implements PacketListener, PacketInterceptor {
             container.getIntegers().writeSafely(0, 9); // Action (9): Update sign text
             NbtCompound nbt = NbtFactory.asCompound(container.getNbtModifier().readSafely(0));
             for (int i = 0; i < 4; i++)
-                nbt.put("Text" + (i + 1), ComponentSerializer.toString(TextComponent.fromLegacyText(lines[i])));
+                nbt.put("Text" + (i + 1), componentSerializer.toString(TextComponent.fromLegacyText(lines[i])));
             nbt.put("name", "null")
                     .put("x", block.getX())
                     .put("y", block.getY())

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/AdvancementsPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/AdvancementsPacketHandler.java
@@ -18,11 +18,9 @@ import com.rexcantor64.triton.utils.NMSUtils;
 import com.rexcantor64.triton.wrappers.WrappedAdvancementDisplay;
 import com.rexcantor64.triton.wrappers.WrappedAdvancementHolder;
 import lombok.val;
-import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
@@ -153,14 +151,14 @@ public class AdvancementsPacketHandler extends PacketHandler {
     }
 
     private void translateAdvancementDisplay(WrappedAdvancementDisplay advancementDisplay, Localized locale) {
-        val originalTitle = ComponentSerializer.parse(advancementDisplay.getTitle().getJson());
-        val originalDescription = ComponentSerializer.parse(advancementDisplay.getDescription().getJson());
+        val originalTitle = componentSerializer().parse(advancementDisplay.getTitle().getJson());
+        val originalDescription = componentSerializer().parse(advancementDisplay.getDescription().getJson());
 
         val translatedTitle = getLanguageParser().parseComponent(locale, getMain().getConf().getAdvancementsSyntax(), originalTitle);
         val translatedDescription = getLanguageParser().parseComponent(locale, getMain().getConf().getAdvancementsSyntax(), originalDescription);
 
-        advancementDisplay.setTitle(WrappedChatComponent.fromJson(ComponentSerializer.toString(translatedTitle)));
-        advancementDisplay.setDescription(WrappedChatComponent.fromJson(ComponentSerializer.toString(translatedDescription)));
+        advancementDisplay.setTitle(WrappedChatComponent.fromJson(componentSerializer().toString(translatedTitle)));
+        advancementDisplay.setDescription(WrappedChatComponent.fromJson(componentSerializer().toString(translatedDescription)));
     }
 
     /**

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/BossBarPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/BossBarPacketHandler.java
@@ -20,7 +20,6 @@ import lombok.Getter;
 import lombok.val;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -174,12 +173,12 @@ public class BossBarPacketHandler extends PacketHandler {
         BaseComponent[] result = getLanguageParser().parseComponent(
                 languagePlayer,
                 getConfig().getBossbarSyntax(),
-                ComponentSerializer.parse(component.getJson())
+                componentSerializer().parse(component.getJson())
         );
         if (result == null) {
             result = new BaseComponent[]{new TranslatableComponent("")};
         }
-        component.setJson(ComponentSerializer.toString(result));
+        component.setJson(componentSerializer().toString(result));
     }
 
     private void translateAndSaveBossBar(SpigotLanguagePlayer languagePlayer, UUID uuid, WrappedChatComponent component) {

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/EntitiesPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/EntitiesPacketHandler.java
@@ -21,7 +21,6 @@ import com.rexcantor64.triton.utils.EntityTypeUtils;
 import com.rexcantor64.triton.utils.ItemStackTranslationUtils;
 import lombok.val;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -474,12 +473,12 @@ public class EntitiesPacketHandler extends PacketHandler {
                 BaseComponent[] result = getLanguageParser().parseComponent(
                         languagePlayer,
                         getConfig().getHologramSyntax(),
-                        ComponentSerializer.parse(msg.getJson())
+                        componentSerializer().parse(msg.getJson())
                 );
                 if (result == null) {
                     msg = null;
                 } else {
-                    msg.setJson(ComponentSerializer.toString(result));
+                    msg.setJson(componentSerializer().toString(result));
                 }
             }
             if (MinecraftVersion.FEATURE_PREVIEW_UPDATE.atOrAbove()) { // 1.19.3
@@ -592,7 +591,7 @@ public class EntitiesPacketHandler extends PacketHandler {
                 val result = getLanguageParser().parseComponent(
                         languagePlayer,
                         getConfig().getHologramSyntax(),
-                        ComponentSerializer.parse(displayName)
+                        componentSerializer().parse(displayName)
                 );
 
                 this.dataValueHandler.getPlayerDisplayNameDataValue(result).ifPresent(dataValues::add);
@@ -611,7 +610,7 @@ public class EntitiesPacketHandler extends PacketHandler {
                 val result = getLanguageParser().parseComponent(
                         languagePlayer,
                         getConfig().getHologramSyntax(),
-                        ComponentSerializer.parse(displayName)
+                        componentSerializer().parse(displayName)
                 );
 
                 this.dataWatcherHandler.getPlayerDisplayNameWatchableObject(result).ifPresent(watchableObjects::add);
@@ -907,7 +906,7 @@ public class EntitiesPacketHandler extends PacketHandler {
             val result = getLanguageParser().parseComponent(
                     languagePlayer,
                     getConfig().getHologramSyntax(),
-                    ComponentSerializer.parse(text)
+                    componentSerializer().parse(text)
             );
 
             final List<WrappedDataValue> dataValues = new ArrayList<>();
@@ -1227,7 +1226,7 @@ public class EntitiesPacketHandler extends PacketHandler {
         Optional<WrappedWatchableObject> getPlayerDisplayNameWatchableObject(BaseComponent[] components) {
             Optional<Object> payload;
             if (components != null) {
-                val wrappedChatComponent = WrappedChatComponent.fromJson(ComponentSerializer.toString(components));
+                val wrappedChatComponent = WrappedChatComponent.fromJson(componentSerializer().toString(components));
                 payload = Optional.of(wrappedChatComponent.getHandle());
             } else {
                 payload = Optional.empty();
@@ -1301,7 +1300,7 @@ public class EntitiesPacketHandler extends PacketHandler {
             val result = getLanguageParser().parseComponent(
                     languagePlayer,
                     getConfig().getHologramSyntax(),
-                    ComponentSerializer.parse(displayNameJson)
+                    componentSerializer().parse(displayNameJson)
             );
 
             if (hasCustomNameConsumer != null) {
@@ -1344,7 +1343,7 @@ public class EntitiesPacketHandler extends PacketHandler {
         Optional<WrappedDataValue> getPlayerDisplayNameDataValue(BaseComponent[] components) {
             Optional<Object> payload;
             if (components != null) {
-                val wrappedChatComponent = WrappedChatComponent.fromJson(ComponentSerializer.toString(components));
+                val wrappedChatComponent = WrappedChatComponent.fromJson(componentSerializer().toString(components));
                 payload = Optional.of(wrappedChatComponent.getHandle());
             } else {
                 payload = Optional.empty();
@@ -1396,7 +1395,7 @@ public class EntitiesPacketHandler extends PacketHandler {
         Optional<WrappedDataValue> getTextDisplayTextDataValue(BaseComponent[] components) {
             Object payload;
             if (components != null) {
-                payload = WrappedChatComponent.fromJson(ComponentSerializer.toString(components)).getHandle();
+                payload = WrappedChatComponent.fromJson(componentSerializer().toString(components)).getHandle();
             } else {
                 payload = WrappedChatComponent.fromText("").getHandle();
             }
@@ -1430,7 +1429,7 @@ public class EntitiesPacketHandler extends PacketHandler {
             val result = getLanguageParser().parseComponent(
                     languagePlayer,
                     getConfig().getHologramSyntax(),
-                    ComponentSerializer.parse(displayNameJson)
+                    componentSerializer().parse(displayNameJson)
             );
 
             if (hasCustomNameConsumer != null) {
@@ -1477,7 +1476,7 @@ public class EntitiesPacketHandler extends PacketHandler {
             val result = getLanguageParser().parseComponent(
                     languagePlayer,
                     getConfig().getHologramSyntax(),
-                    ComponentSerializer.parse(displayNameJson)
+                    componentSerializer().parse(displayNameJson)
             );
 
             return this.getTextDisplayTextDataValue(result);

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/MotdPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/MotdPacketHandler.java
@@ -11,7 +11,6 @@ import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.utils.ComponentUtils;
 import lombok.val;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.entity.Player;
 
 import java.net.InetAddress;
@@ -70,10 +69,11 @@ public class MotdPacketHandler extends PacketAdapter {
         serverPing.setVersionName(Triton.get().getLanguageParser().replaceLanguages(serverPing.getVersionName(), lang, syntax));
 
         val motd = serverPing.getMotD();
+        val serializer = Triton.get().getComponentSerializer();
         val result = Triton.get().getLanguageParser()
-                .parseComponent(lang, syntax, ComponentSerializer.parse(motd.getJson()));
+                .parseComponent(lang, syntax, serializer.parse(motd.getJson()));
         if (result != null)
-            motd.setJson(ComponentSerializer.toString(result));
+            motd.setJson(serializer.toString(result));
         serverPing.setMotD(motd);
 
         if (MinecraftVersion.FEATURE_PREVIEW_2.atOrAbove()) {

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/PacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/PacketHandler.java
@@ -9,6 +9,8 @@ import com.rexcantor64.triton.config.MainConfig;
 import com.rexcantor64.triton.language.LanguageManager;
 import com.rexcantor64.triton.language.LanguageParser;
 import com.rexcantor64.triton.logger.TritonLogger;
+import com.rexcantor64.triton.utils.VersionedComponentUtils;
+import net.md_5.bungee.chat.VersionedComponentSerializer;
 import org.bukkit.entity.Player;
 
 import java.util.Map;
@@ -35,6 +37,10 @@ public abstract class PacketHandler {
 
     protected LanguageParser getLanguageParser() {
         return getMain().getLanguageParser();
+    }
+
+    protected VersionedComponentUtils componentSerializer() {
+        return getMain().getComponentSerializer();
     }
 
     /**

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/SignPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/protocollib/SignPacketHandler.java
@@ -22,7 +22,6 @@ import com.rexcantor64.triton.utils.ComponentUtils;
 import com.rexcantor64.triton.utils.NbtUtils;
 import lombok.val;
 import net.md_5.bungee.api.chat.TextComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
@@ -191,7 +190,7 @@ public class SignPacketHandler extends PacketHandler {
             for (int i = 0; i < 4; i++) {
                 try {
                     defaultLines[i] = AdvancedComponent
-                            .fromBaseComponent(ComponentSerializer.parse(defaultLinesWrapped[i].getJson()))
+                            .fromBaseComponent(componentSerializer().parse(defaultLinesWrapped[i].getJson()))
                             .getTextClean();
                 } catch (Exception e) {
                     Triton.get().getLogger().logError(e, "Failed to parse sign line %1 at %2.", i + 1, l);
@@ -204,7 +203,7 @@ public class SignPacketHandler extends PacketHandler {
         val comps = new WrappedChatComponent[4];
         for (int i = 0; i < 4; i++)
             comps[i] =
-                    WrappedChatComponent.fromJson(ComponentSerializer.toString(TextComponent.fromLegacyText(lines[i])));
+                    WrappedChatComponent.fromJson(componentSerializer().toString(TextComponent.fromLegacyText(lines[i])));
         linesModifier.writeSafely(0, comps);
 
         languagePlayer.getLegacySigns().put(l, Arrays.stream(defaultLinesWrapped).map(WrappedChatComponent::getJson).toArray(String[]::new));
@@ -244,7 +243,7 @@ public class SignPacketHandler extends PacketHandler {
                 for (int i = 0; i < 4; i++) {
                     try {
                         defaultLines[i] = AdvancedComponent
-                                .fromBaseComponent(ComponentSerializer.parse(lines[i]))
+                                .fromBaseComponent(componentSerializer().parse(lines[i]))
                                 .getTextClean();
                     } catch (Exception e) {
                         Triton.get().getLogger().logError(e, "Failed to parse sign line %1 at %2.", i + 1, signLocation);
@@ -326,7 +325,7 @@ public class SignPacketHandler extends PacketHandler {
         val comps = new WrappedChatComponent[4];
         for (int i = 0; i < 4; ++i)
             comps[i] =
-                    WrappedChatComponent.fromJson(ComponentSerializer
+                    WrappedChatComponent.fromJson(componentSerializer()
                             .toString(TextComponent.fromLegacyText(lines[i])));
         packet.getChatComponentArrays().writeSafely(0, comps);
 
@@ -365,7 +364,7 @@ public class SignPacketHandler extends PacketHandler {
                     val nbtLine = compound.getStringOrDefault("Text" + (i + 1));
                     if (nbtLine != null)
                         defaultLines[i] = AdvancedComponent
-                                .fromBaseComponent(ComponentSerializer.parse(nbtLine))
+                                .fromBaseComponent(componentSerializer().parse(nbtLine))
                                 .getTextClean();
                 } catch (Exception e) {
                     Triton.get().getLogger().logError(e, "Failed to parse sign line %1 at %2.", i + 1, location);
@@ -377,7 +376,7 @@ public class SignPacketHandler extends PacketHandler {
         if (sign != null) {
             val compoundClone = saveToCache ? NbtFactory.asCompound(compound.deepClone()) : null;
             for (int i = 0; i < 4; i++) {
-                compound.put("Text" + (i + 1), ComponentSerializer.toString(TextComponent.fromLegacyText(sign[i])));
+                compound.put("Text" + (i + 1), componentSerializer().toString(TextComponent.fromLegacyText(sign[i])));
             }
             if (compoundClone != null) {
                 player.saveSign(location, typeKey, compoundClone);
@@ -403,7 +402,7 @@ public class SignPacketHandler extends PacketHandler {
                     try {
                         val nbtLine = NbtUtils.toJson(frontTextMessages.get(i));
                         defaultLines[i] = AdvancedComponent
-                                .fromBaseComponent(ComponentSerializer.deserialize(nbtLine))
+                                .fromBaseComponent(componentSerializer().deserialize(nbtLine))
                                 .getTextClean();
                     } catch (Exception e) {
                         Triton.get().getLogger().logError(e, "Failed to parse sign line %1 (front) at %2.", i + 1, location);
@@ -416,7 +415,7 @@ public class SignPacketHandler extends PacketHandler {
                         val nbtLine = frontTextMessages.getValue(i);
                         if (nbtLine != null)
                             defaultLines[i] = AdvancedComponent
-                                    .fromBaseComponent(ComponentSerializer.parse(nbtLine))
+                                    .fromBaseComponent(componentSerializer().parse(nbtLine))
                                     .getTextClean();
                     } catch (Exception e) {
                         Triton.get().getLogger().logError(e, "Failed to parse sign line %1 (front) at %2.", i + 1, location);
@@ -430,7 +429,7 @@ public class SignPacketHandler extends PacketHandler {
                     try {
                         val nbtLine = NbtUtils.toJson(backTextMessages.get(i));
                         defaultLines[i + 4] = AdvancedComponent
-                                .fromBaseComponent(ComponentSerializer.deserialize(nbtLine))
+                                .fromBaseComponent(componentSerializer().deserialize(nbtLine))
                                 .getTextClean();
                     } catch (Exception e) {
                         Triton.get().getLogger().logError(e, "Failed to parse sign line %1 (back) at %2.", i + 1, location);
@@ -443,7 +442,7 @@ public class SignPacketHandler extends PacketHandler {
                         val nbtLine = backTextMessages.getValue(i);
                         if (nbtLine != null)
                             defaultLines[i + 4] = AdvancedComponent
-                                    .fromBaseComponent(ComponentSerializer.parse(nbtLine))
+                                    .fromBaseComponent(componentSerializer().parse(nbtLine))
                                     .getTextClean();
                     } catch (Exception e) {
                         Triton.get().getLogger().logError(e, "Failed to parse sign line %1 (back) at %2.", i + 1, location);
@@ -461,7 +460,7 @@ public class SignPacketHandler extends PacketHandler {
                 val frontTextMessages = Arrays.stream(sign, 0, 4)
                         .map(TextComponent::fromLegacyText)
                         .map(ComponentUtils::toSingleBaseComponent)
-                        .map(ComponentSerializer::toJson)
+                        .map(c -> componentSerializer().toJson(c))
                         .map(NbtUtils::fromJson)
                         .peek(t -> t.setName(""))
                         .collect(Collectors.toList());
@@ -469,7 +468,7 @@ public class SignPacketHandler extends PacketHandler {
             } else {
                 val frontTextMessages = Arrays.stream(sign, 0, 4)
                         .map(TextComponent::fromLegacyText)
-                        .map(ComponentSerializer::toString)
+                        .map(c -> componentSerializer().toString(c))
                         .collect(Collectors.toList());
                 frontText.put("messages", NbtFactory.ofList("messages", frontTextMessages));
             }
@@ -479,7 +478,7 @@ public class SignPacketHandler extends PacketHandler {
                 val backTextMessages = Arrays.stream(sign, 4, 8)
                         .map(TextComponent::fromLegacyText)
                         .map(ComponentUtils::toSingleBaseComponent)
-                        .map(ComponentSerializer::toJson)
+                        .map(c -> componentSerializer().toJson(c))
                         .map(NbtUtils::fromJson)
                         .peek(t -> t.setName(""))
                         .collect(Collectors.toList());
@@ -487,7 +486,7 @@ public class SignPacketHandler extends PacketHandler {
             } else {
                 val backTextMessages = Arrays.stream(sign, 4, 8)
                         .map(TextComponent::fromLegacyText)
-                        .map(ComponentSerializer::toString)
+                        .map(c -> componentSerializer().toString(c))
                         .collect(Collectors.toList());
                 backText.put("messages", NbtFactory.ofList("messages", backTextMessages));
             }

--- a/core/src/main/java/com/rexcantor64/triton/utils/ItemStackTranslationUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/ItemStackTranslationUtils.java
@@ -14,7 +14,11 @@ import com.google.gson.JsonParseException;
 import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.api.language.Localized;
 import com.rexcantor64.triton.config.MainConfig;
-import com.rexcantor64.triton.wrappers.items.*;
+import com.rexcantor64.triton.wrappers.items.WrappedFilterable;
+import com.rexcantor64.triton.wrappers.items.WrappedItemContainerContents;
+import com.rexcantor64.triton.wrappers.items.WrappedItemLore;
+import com.rexcantor64.triton.wrappers.items.WrappedPatchedDataComponentMap;
+import com.rexcantor64.triton.wrappers.items.WrappedWrittenBookContent;
 import lombok.val;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -26,7 +30,11 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ItemStackTranslationUtils {
@@ -113,10 +121,10 @@ public class ItemStackTranslationUtils {
                                 .parseComponent(
                                         languagePlayer,
                                         main().getConf().getItemsSyntax(),
-                                        ComponentSerializer.parse(page.getValue())
+                                        main().getComponentSerializer().parse(page.getValue())
                                 );
                         if (result != null) {
-                            newPagesCollection.add(ComponentSerializer.toString(result));
+                            newPagesCollection.add(main().getComponentSerializer().toString(result));
                         }
                     } catch (JsonParseException e) {
                         String result = translate(
@@ -126,7 +134,7 @@ public class ItemStackTranslationUtils {
                         );
                         if (result != null) {
                             newPagesCollection.add(
-                                    ComponentSerializer.toString(
+                                    main().getComponentSerializer().toString(
                                             TextComponent.fromLegacyText(result)));
                         }
                     }
@@ -152,12 +160,12 @@ public class ItemStackTranslationUtils {
                     .parseComponent(
                             languagePlayer,
                             main().getConf().getItemsSyntax(),
-                            ComponentSerializer.parse(customName.getJson())
+                            main().getComponentSerializer().parse(customName.getJson())
                     );
             if (result == null) {
                 componentMap.setCustomName(null);
             } else {
-                customName.setJson(ComponentSerializer.toString(ComponentUtils.ensureNotItalic(Arrays.stream(result))));
+                customName.setJson(main().getComponentSerializer().toString(ComponentUtils.ensureNotItalic(Arrays.stream(result))));
                 componentMap.setCustomName(customName);
             }
         }
@@ -172,13 +180,13 @@ public class ItemStackTranslationUtils {
                             .parseComponent(
                                     languagePlayer,
                                     main().getConf().getItemsSyntax(),
-                                    ComponentSerializer.parse(line.getJson())
+                                    main().getComponentSerializer().parse(line.getJson())
                             );
                     if (result != null) {
                         List<List<BaseComponent>> splitLoreLines = ComponentUtils.splitByNewLine(Arrays.asList(result));
                         newLines.addAll(splitLoreLines.stream()
                                 .map(comps -> ComponentUtils.ensureNotItalic(comps.stream()))
-                                .map(ComponentSerializer::toString)
+                                .map(main().getComponentSerializer()::toString)
                                 .map(WrappedChatComponent::fromJson)
                                 .collect(Collectors.toList()));
                     }
@@ -210,10 +218,10 @@ public class ItemStackTranslationUtils {
                             .parseComponent(
                                     languagePlayer,
                                     main().getConf().getItemsSyntax(),
-                                    ComponentSerializer.parse(raw.getJson())
+                                    main().getComponentSerializer().parse(raw.getJson())
                             );
                     if (result != null) {
-                        raw.setJson(ComponentSerializer.toString(result));
+                        raw.setJson(main().getComponentSerializer().toString(result));
                         page.setRaw(raw);
                         newPages.add(page);
                     }
@@ -273,7 +281,7 @@ public class ItemStackTranslationUtils {
                 if (result == null) {
                     display.remove("Name");
                 } else {
-                    display.put("Name", ComponentSerializer.toString(ComponentUtils.ensureNotItalic(Arrays.stream(result))));
+                    display.put("Name", main().getComponentSerializer().toString(ComponentUtils.ensureNotItalic(Arrays.stream(result))));
                 }
             } catch (JsonParseException e) {
                 String result = translate(name, languagePlayer, main().getConf().getItemsSyntax());
@@ -301,7 +309,7 @@ public class ItemStackTranslationUtils {
                         List<List<BaseComponent>> splitLoreLines = ComponentUtils.splitByNewLine(Arrays.asList(result));
                         newLore.addAll(splitLoreLines.stream()
                                 .map(comps -> ComponentUtils.ensureNotItalic(comps.stream()))
-                                .map(ComponentSerializer::toString)
+                                .map(main().getComponentSerializer()::toString)
                                 .collect(Collectors.toList()));
                     }
                 } catch (JsonParseException e) {
@@ -359,7 +367,7 @@ public class ItemStackTranslationUtils {
         if (!MinecraftVersion.AQUATIC_UPDATE.atOrAbove()) { // MC 1.13
             throw new JsonParseException("This Minecraft version does not support JSON text on items");
         }
-        return ComponentSerializer.parse(json);
+        return main().getComponentSerializer().parse(json);
     }
 
     private static Triton main() {

--- a/core/src/main/java/com/rexcantor64/triton/utils/VersionedComponentUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/VersionedComponentUtils.java
@@ -1,0 +1,38 @@
+package com.rexcantor64.triton.utils;
+
+import com.google.gson.JsonElement;
+import lombok.RequiredArgsConstructor;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.VersionedComponentSerializer;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("UnstableApiUsage")
+@RequiredArgsConstructor
+public class VersionedComponentUtils {
+
+    private final @NotNull VersionedComponentSerializer serializer;
+
+    public BaseComponent[] parse(String json) {
+        return serializer.parse(json);
+    }
+
+    public BaseComponent deserialize(String json) {
+        return serializer.deserialize(json);
+    }
+
+    public BaseComponent deserialize(JsonElement json) {
+        return serializer.deserialize(json);
+    }
+
+    public String toString(BaseComponent... component) {
+        return serializer.toString(component);
+    }
+
+    public JsonElement toJson(BaseComponent component) {
+        return serializer.toJson(component);
+    }
+
+    public BaseComponent[] reparse(BaseComponent... component) {
+        return serializer.parse(serializer.toString(component));
+    }
+}

--- a/core/src/main/java/com/rexcantor64/triton/wrappers/AdventureComponentWrapper.java
+++ b/core/src/main/java/com/rexcantor64/triton/wrappers/AdventureComponentWrapper.java
@@ -1,14 +1,14 @@
 package com.rexcantor64.triton.wrappers;
 
+import com.rexcantor64.triton.Triton;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
 
 public class AdventureComponentWrapper {
 
     public static BaseComponent[] toMd5Component(Object component) {
-        return ComponentSerializer.parse(toJson(component));
+        return Triton.get().getComponentSerializer().parse(toJson(component));
     }
 
     public static String toJson(Object component) {


### PR DESCRIPTION
md5's ComponentSerializer defaults to the 1.16 serializer even on 1.21.5 and above, so the hover and click events are not compatible with the 1.21.5 format.

Fixes #535