### PR TITLE
fix(bungee): error while injecting adventure into gson

### DIFF
--- a/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/utils/BaseComponentUtils.java
+++ b/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/utils/BaseComponentUtils.java
@@ -22,10 +22,13 @@ public class BaseComponentUtils {
         // I hate this
         // https://github.com/KyoriPowered/adventure-platform/blob/36ab6311d9023a4f67d2db6a2e057d9ee3f8a8a7/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudiencesImpl.java#L63-L70
         try {
-            final Field gsonField = ProxyServer.getInstance().getClass().getDeclaredField("gson");
-            gsonField.setAccessible(true);
-            final Gson gson = (Gson) gsonField.get(ProxyServer.getInstance());
-            BungeeComponentSerializer.inject(gson);
+            // no need to do anything if it has failed to inject anyway
+            if (BungeeComponentSerializer.isNative()) {
+                final Field gsonField = ProxyServer.getInstance().getClass().getDeclaredField("gson");
+                gsonField.setAccessible(true);
+                final Gson gson = (Gson) gsonField.get(ProxyServer.getInstance());
+                BungeeComponentSerializer.inject(gson);
+            }
         } catch (final Throwable error) {
             Triton.get().getLogger().logError(error, "Failed to inject ProxyServer gson");
         }


### PR DESCRIPTION
BungeeCord has changed where it stores its Gson instances, making this code fail. However, instead of fixing the underlying issue, we are now skipping the injection if the serialisation is not native anyway, since it would require changes in adventure-platform.
Once upstream fixes the injection issue, we can update the code to inject in the appropriate places.

Closes #534