### PR TITLE
fix(spigot): error initializing versioned serializer on 1.21.4 and older

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/BungeeMLP.java
+++ b/core/src/main/java/com/rexcantor64/triton/BungeeMLP.java
@@ -52,7 +52,7 @@ public class BungeeMLP extends Triton {
         super.onEnable();
 
         // noinspection UnstableApiUsage,deprecation
-        componentSerializer = new VersionedComponentUtils(VersionedComponentSerializer.getDefault());
+        componentSerializer = new VersionedComponentUtils.Versioned(VersionedComponentSerializer.getDefault());
 
         Metrics metrics = new Metrics(getLoader(), 5607);
         metrics.addCustomChart(new SingleLineChart("active_placeholders",

--- a/core/src/main/java/com/rexcantor64/triton/SpigotMLP.java
+++ b/core/src/main/java/com/rexcantor64/triton/SpigotMLP.java
@@ -158,9 +158,9 @@ public class SpigotMLP extends Triton {
     @SuppressWarnings("UnstableApiUsage")
     private void setupVersionedComponentSerializer() {
         if (MinecraftVersion.v1_21_5.atOrAbove()) {
-            componentSerializer = new VersionedComponentUtils(VersionedComponentSerializer.forVersion(ChatVersion.V1_21_5));
+            componentSerializer = new VersionedComponentUtils.Versioned(VersionedComponentSerializer.forVersion(ChatVersion.V1_21_5));
         } else {
-            componentSerializer = new VersionedComponentUtils(VersionedComponentSerializer.forVersion(ChatVersion.V1_16));
+            componentSerializer = new VersionedComponentUtils.Legacy();
         }
     }
 

--- a/core/src/main/java/com/rexcantor64/triton/utils/VersionedComponentUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/VersionedComponentUtils.java
@@ -3,36 +3,90 @@ package com.rexcantor64.triton.utils;
 import com.google.gson.JsonElement;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.chat.VersionedComponentSerializer;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("UnstableApiUsage")
-@RequiredArgsConstructor
-public class VersionedComponentUtils {
+public interface VersionedComponentUtils {
 
-    private final @NotNull VersionedComponentSerializer serializer;
+    BaseComponent[] parse(String json);
 
-    public BaseComponent[] parse(String json) {
-        return serializer.parse(json);
+    BaseComponent deserialize(String json);
+
+    BaseComponent deserialize(JsonElement json);
+
+    String toString(BaseComponent... component);
+
+    JsonElement toJson(BaseComponent component);
+
+    BaseComponent[] reparse(BaseComponent... component);
+
+    @RequiredArgsConstructor
+    class Versioned implements VersionedComponentUtils {
+        private final @NotNull VersionedComponentSerializer serializer;
+
+        @Override
+        public BaseComponent[] parse(String json) {
+            return serializer.parse(json);
+        }
+
+        @Override
+        public BaseComponent deserialize(String json) {
+            return serializer.deserialize(json);
+        }
+
+        @Override
+        public BaseComponent deserialize(JsonElement json) {
+            return serializer.deserialize(json);
+        }
+
+        @Override
+        public String toString(BaseComponent... component) {
+            return serializer.toString(component);
+        }
+
+        @Override
+        public JsonElement toJson(BaseComponent component) {
+            return serializer.toJson(component);
+        }
+
+        @Override
+        public BaseComponent[] reparse(BaseComponent... component) {
+            return serializer.parse(serializer.toString(component));
+        }
     }
 
-    public BaseComponent deserialize(String json) {
-        return serializer.deserialize(json);
-    }
+    class Legacy implements VersionedComponentUtils {
 
-    public BaseComponent deserialize(JsonElement json) {
-        return serializer.deserialize(json);
-    }
+        @Override
+        public BaseComponent[] parse(String json) {
+            return ComponentSerializer.parse(json);
+        }
 
-    public String toString(BaseComponent... component) {
-        return serializer.toString(component);
-    }
+        @Override
+        public BaseComponent deserialize(String json) {
+            return ComponentSerializer.deserialize(json);
+        }
 
-    public JsonElement toJson(BaseComponent component) {
-        return serializer.toJson(component);
-    }
+        @Override
+        public BaseComponent deserialize(JsonElement json) {
+            return ComponentSerializer.deserialize(json);
+        }
 
-    public BaseComponent[] reparse(BaseComponent... component) {
-        return serializer.parse(serializer.toString(component));
+        @Override
+        public String toString(BaseComponent... component) {
+            return ComponentSerializer.toString(component);
+        }
+
+        @Override
+        public JsonElement toJson(BaseComponent component) {
+            return ComponentSerializer.toJson(component);
+        }
+
+        @Override
+        public BaseComponent[] reparse(BaseComponent... component) {
+            return ComponentSerializer.parse(ComponentSerializer.toString(component));
+        }
     }
 }


### PR DESCRIPTION
This happened because the VersionedComponentSerializer class does not exist on 1.21.4 and older.

See a91ac160456085f67f07249cfd3fde9864a9abca