### PR TITLE
fix(core): skip downloading from maven central and ensure relocations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ allprojects {
         mavenLocal()
         mavenCentral()
         maven {
+            name = 'diogotcRepositoryReleases'
+            url = 'https://repo.diogotc.com/releases/'
+        }
+        maven {
             name = 'diogotcRepositorySnapshots'
             url = 'https://repo.diogotc.com/snapshots/'
         }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     }
     compileOnly 'com.google.code.gson:gson:2.9.0'
 
-    implementation 'net.byteflux:libby-core:1.3.0'
+    implementation 'com.rexcantor64:libby-core:2.0.0'
 
     // Test dependencies
     testImplementation project(":api")
@@ -63,4 +63,7 @@ shadowJar {
     relocate 'com.zaxxer.hikari', 'com.rexcantor64.shaded.hikari'
 
     relocate 'net.byteflux.libby', 'com.rexcantor64.triton.lib.libby'
+
+    relocate 'org.objectweb.asm', 'com.rexcantor64.triton.lib.objectweb.asm'
+    relocate 'me.lucko.jarrelocator', 'com.rexcantor64.triton.lib.jarrelocator'
 }

--- a/core/loader/build.gradle
+++ b/core/loader/build.gradle
@@ -5,7 +5,7 @@ plugins {
 group = 'com.rexcantor64.triton'
 
 dependencies {
-    api 'org.ow2.asm:asm-commons:9.2'
-    api 'org.ow2.asm:asm:9.2'
+    api 'org.ow2.asm:asm-commons:9.9'
+    api 'org.ow2.asm:asm:9.9'
     api 'me.lucko:jar-relocator:1.7'
 }

--- a/core/src/main/java/com/rexcantor64/triton/dependencies/DependencyManager.java
+++ b/core/src/main/java/com/rexcantor64/triton/dependencies/DependencyManager.java
@@ -30,6 +30,7 @@ public class DependencyManager {
 
         libraryManager.addRepository(Repository.DIOGOTC_MIRROR);
         libraryManager.addMavenCentral();
+        libraryManager.setRelocator(new NativeRelocationHelper());
 
         if (hasLoaderFlag(LoaderFlag.SHADE_ADVENTURE)) {
             if (hasLoaderFlag(LoaderFlag.RELOCATE_ADVENTURE)) {

--- a/core/src/main/java/com/rexcantor64/triton/dependencies/NativeRelocationHelper.java
+++ b/core/src/main/java/com/rexcantor64/triton/dependencies/NativeRelocationHelper.java
@@ -1,0 +1,38 @@
+package com.rexcantor64.triton.dependencies;
+
+import me.lucko.jarrelocator.JarRelocator;
+import net.byteflux.libby.relocation.Relocation;
+import net.byteflux.libby.relocation.RelocationHelper;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class NativeRelocationHelper implements RelocationHelper {
+    @Override
+    public void relocate(Path in, Path out, Collection<Relocation> relocations) {
+        requireNonNull(in, "in");
+        requireNonNull(out, "out");
+        requireNonNull(relocations, "relocations");
+
+        try {
+            List<me.lucko.jarrelocator.Relocation> rules = new LinkedList<>();
+            for (Relocation relocation : relocations) {
+                rules.add(new me.lucko.jarrelocator.Relocation(
+                        relocation.getPattern(),
+                        relocation.getRelocatedPattern(),
+                        relocation.getIncludes(),
+                        relocation.getExcludes()
+                ));
+            }
+
+            new JarRelocator(in.toFile(), out.toFile(), rules).run();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/triton-bungeecord/build.gradle
+++ b/triton-bungeecord/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.4.0'
 
-    implementation 'net.byteflux:libby-bungee:1.3.0'
+    implementation 'com.rexcantor64:libby-bungee:2.0.0'
 
     implementation 'org.bstats:bstats-bungeecord:3.1.0'
 }

--- a/triton-spigot/build.gradle
+++ b/triton-spigot/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     // Libraries available on Spigot
     compileOnly 'org.fusesource.jansi:jansi:2.4.0' // Used for terminal translation
 
-    implementation 'net.byteflux:libby-bukkit:1.3.0'
+    implementation 'com.rexcantor64:libby-bukkit:2.0.0'
 
     implementation 'org.bstats:bstats-bukkit:3.1.0'
 

--- a/triton-velocity/build.gradle
+++ b/triton-velocity/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     // FIXME in the future change this to dynamic download and loading
     implementation 'mysql:mysql-connector-java:8.0.30'
 
-    implementation 'net.byteflux:libby-velocity:1.3.0'
+    implementation 'com.rexcantor64:libby-velocity:2.0.0'
 
     implementation 'org.bstats:bstats-velocity:3.1.0'
 


### PR DESCRIPTION
Libby has been forked [1], which adds functionality to avoid downloading the dependencies for relocation from maven central (they are already shaded into the Triton jar), and also includes the hash of the applied relocations to the file names, ensuring they are always up-to-date.

Fixes #416
Fixes #417

[1]: https://github.com/tritonmc/libby