### PR TITLE
refactor(core): reorganize loader flags for adventure

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     compileOnly 'org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT'
     compileOnly 'net.md-5:bungeecord-api:1.21-R0.4-SNAPSHOT'
 
-    compileOnly 'net.kyori:adventure-api:4.23.0'
-    compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.4.0'
+    compileOnly 'net.kyori:adventure-api:4.25.0'
+    compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.4.1'
 }
 
 task javadocJar(type: Jar) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -14,10 +14,10 @@ dependencies {
     compileOnly project(":api")
 
     // Adventure / MiniMessage
-    compileOnly 'net.kyori:adventure-text-serializer-gson:4.23.0'
-    compileOnly 'net.kyori:adventure-text-serializer-legacy:4.23.0'
-    compileOnly 'net.kyori:adventure-text-serializer-plain:4.23.0'
-    compileOnly('net.kyori:adventure-text-minimessage:4.23.0') {
+    compileOnly 'net.kyori:adventure-text-serializer-gson:4.25.0'
+    compileOnly 'net.kyori:adventure-text-serializer-legacy:4.25.0'
+    compileOnly 'net.kyori:adventure-text-serializer-plain:4.25.0'
+    compileOnly('net.kyori:adventure-text-minimessage:4.25.0') {
         exclude group: 'net.kyori', module: 'adventure-api'
         exclude group: 'net.kyori', module: 'adventure-key'
         exclude group: 'net.kyori', module: 'adventure-text-serialize-gson'
@@ -48,10 +48,10 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 
-    testImplementation 'net.kyori:adventure-api:4.23.0'
-    testImplementation 'net.kyori:adventure-text-serializer-gson:4.23.0'
-    testImplementation 'net.kyori:adventure-text-serializer-legacy:4.23.0'
-    testImplementation 'net.kyori:adventure-text-serializer-plain:4.23.0'
+    testImplementation 'net.kyori:adventure-api:4.25.0'
+    testImplementation 'net.kyori:adventure-text-serializer-gson:4.25.0'
+    testImplementation 'net.kyori:adventure-text-serializer-legacy:4.25.0'
+    testImplementation 'net.kyori:adventure-text-serializer-plain:4.25.0'
 }
 
 shadowJar {

--- a/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/CommonLoader.java
+++ b/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/CommonLoader.java
@@ -31,19 +31,19 @@ public class CommonLoader {
 
     public LoaderBootstrap loadPlugin() {
         List<Relocation> relocations = new ArrayList<>();
-        if (flags.contains(LoaderFlag.SHADE_ADVENTURE)) {
-            if (flags.contains(LoaderFlag.RELOCATE_ADVENTURE)) {
-                relocations.add(new Relocation("net/kyori/adventure", "com/rexcantor64/triton/lib/adventure"));
-                relocations.add(new Relocation("net/kyori/examination", "com/rexcantor64/triton/lib/kyori/examination"));
-            } else {
-                // relocate only specific adventure libraries (instead of everything)
-                relocations.add(new Relocation("net/kyori/adventure/text/minimessage", "com/rexcantor64/triton/lib/adventure/text/minimessage"));
-                relocations.add(new Relocation("net/kyori/adventure/text/serializer/gson", "com/rexcantor64/triton/lib/adventure/text/serializer/gson"));
-                relocations.add(new Relocation("net/kyori/adventure/text/serializer/legacy", "com/rexcantor64/triton/lib/adventure/text/serializer/legacy"));
-                relocations.add(new Relocation("net/kyori/adventure/text/serializer/plain", "com/rexcantor64/triton/lib/adventure/text/serializer/plain"));
-                relocations.add(new Relocation("net/kyori/adventure/text/serializer/bungeecord", "com/rexcantor64/triton/lib/adventure/text/serializer/bungeecord"));
-            }
+        if (flags.contains(LoaderFlag.VENDOR_ADVENTURE)) {
+            relocations.add(new Relocation("net/kyori/adventure", "com/rexcantor64/triton/lib/adventure"));
+            relocations.add(new Relocation("net/kyori/examination", "com/rexcantor64/triton/lib/kyori/examination"));
+        }
+        if (flags.contains(LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS)) {
+            relocations.add(new Relocation("net/kyori/adventure/text/minimessage", "com/rexcantor64/triton/lib/adventure/text/minimessage"));
+            relocations.add(new Relocation("net/kyori/adventure/text/serializer/gson", "com/rexcantor64/triton/lib/adventure/text/serializer/gson"));
+            relocations.add(new Relocation("net/kyori/adventure/text/serializer/legacy", "com/rexcantor64/triton/lib/adventure/text/serializer/legacy"));
+            relocations.add(new Relocation("net/kyori/adventure/text/serializer/plain", "com/rexcantor64/triton/lib/adventure/text/serializer/plain"));
             relocations.add(new Relocation("net/kyori/option", "com/rexcantor64/triton/lib/kyori/option"));
+        }
+        if (flags.contains(LoaderFlag.VENDOR_ADVENTURE_BUNGEE_SERIALIZER)) {
+            relocations.add(new Relocation("net/kyori/adventure/text/serializer/bungeecord", "com/rexcantor64/triton/lib/adventure/text/serializer/bungeecord"));
         }
 
         if (flags.contains(LoaderFlag.VENDOR_PACKET_EVENTS)) {

--- a/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/LoaderFlag.java
+++ b/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/LoaderFlag.java
@@ -1,7 +1,12 @@
 package com.rexcantor64.triton.loader.utils;
 
 public enum LoaderFlag {
-    SHADE_ADVENTURE,
-    RELOCATE_ADVENTURE,
+    /** Vendor the Adventure core and examination API */
+    VENDOR_ADVENTURE,
+    /** Vendor Minimessage, Kyori option and all Adventure serializers EXCEPT the BungeeCord one */
+    VENDOR_ADVENTURE_SERIALIZERS,
+    /** Vendor the Bungee Serializer */
+    VENDOR_ADVENTURE_BUNGEE_SERIALIZER,
+    /** Vendor packetevents */
     VENDOR_PACKET_EVENTS,
 }

--- a/core/src/main/java/com/rexcantor64/triton/dependencies/Dependency.java
+++ b/core/src/main/java/com/rexcantor64/triton/dependencies/Dependency.java
@@ -26,55 +26,53 @@ public enum Dependency {
             "adventure-text-serializer-gson",
             "4.25.0",
             "kx9nlZ1G4P5Vtkq5Fk4xtXi3kjV4f2nUcrYoZfl7ckU=",
+            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
+            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             relocate("net{}kyori{}option", "kyori{}option"),
-            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}gson", "adventure{}text{}serializer{}gson", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}json", "adventure{}text{}serializer{}json", LoaderFlag.RELOCATE_ADVENTURE)
+            relocate("net{}kyori{}adventure{}text{}serializer{}gson", "adventure{}text{}serializer{}gson"),
+            relocate("net{}kyori{}adventure{}text{}serializer{}json", "adventure{}text{}serializer{}json")
     ),
     ADVENTURE_TEXT_SERIALIZER_LEGACY(
             "net{}kyori",
             "adventure-text-serializer-legacy",
             "4.25.0",
             "BvFSXr8X+080w08bUmKt5nJwXBFj9qSLaKTgMU36ahM=",
-            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}legacy", "adventure{}text{}serializer{}legacy", LoaderFlag.RELOCATE_ADVENTURE)
+            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
+            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
+            relocate("net{}kyori{}adventure{}text{}serializer{}legacy", "adventure{}text{}serializer{}legacy")
     ),
     ADVENTURE_TEXT_SERIALIZER_PLAIN(
             "net{}kyori",
             "adventure-text-serializer-plain",
             "4.25.0",
             "lFN1egpsDdnktfzSVOgqfqhn9MvkA3cWf0QMQexgUu4=",
-            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}plain", "adventure{}text{}serializer{}plain", LoaderFlag.RELOCATE_ADVENTURE)
+            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
+            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
+            relocate("net{}kyori{}adventure{}text{}serializer{}plain", "adventure{}text{}serializer{}plain")
     ),
     ADVENTURE_TEXT_SERIALIZER_BUNGEECORD(
             "net{}kyori",
             "adventure-text-serializer-bungeecord",
             "4.4.1",
             "4bw3bG3HohAAFgFXNc5MzFNNKya/WrgqrHUcUDIFbDk=",
-            relocate("net{}kyori{}option", "kyori{}option"),
-            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}bungeecord", "adventure{}text{}serializer{}bungeecord", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}gson", "adventure{}text{}serializer{}gson", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}json", "adventure{}text{}serializer{}json", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}legacy", "adventure{}text{}serializer{}legacy", LoaderFlag.RELOCATE_ADVENTURE)
+            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
+            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
+            relocate("net{}kyori{}adventure{}text{}serializer{}bungeecord", "adventure{}text{}serializer{}bungeecord"),
+            relocateIf("net{}kyori{}adventure{}text{}serializer{}gson", "adventure{}text{}serializer{}gson", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),
+            relocateIf("net{}kyori{}adventure{}text{}serializer{}json", "adventure{}text{}serializer{}json", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS)
     ),
     ADVENTURE_MINI_MESSAGE(
             "net{}kyori",
             "adventure-text-minimessage",
             "4.25.0",
             "GY8nxvkeXjJxZAZQhp/v3WgW17MQtIz6UptfWOSpKaQ=",
+            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
+            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             relocate("net{}kyori{}option", "kyori{}option"),
-            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}minimessage", "adventure{}text{}minimessage", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}gson", "adventure{}text{}serializer{}gson", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}json", "adventure{}text{}serializer{}json", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}legacy", "adventure{}text{}serializer{}legacy", LoaderFlag.RELOCATE_ADVENTURE)
+            relocate("net{}kyori{}adventure{}text{}minimessage", "adventure{}text{}minimessage"),
+            relocate("net{}kyori{}adventure{}text{}serializer{}gson", "adventure{}text{}serializer{}gson"),
+            relocate("net{}kyori{}adventure{}text{}serializer{}json", "adventure{}text{}serializer{}json"),
+            relocate("net{}kyori{}adventure{}text{}serializer{}legacy", "adventure{}text{}serializer{}legacy")
     ),
 
     // Dependencies of Adventure
@@ -84,17 +82,17 @@ public enum Dependency {
             "4.25.0",
             "zsjwq/ZC3w5ie/Wp//bxfLtiDqb+BfIWK5bK0VZNiFc=",
             relocate("net{}kyori{}adventure", "adventure"),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE)
+            relocate("net{}kyori{}examination", "kyori{}examination")
     ),
     ADVENTURE_TEXT_SERIALIZER_JSON(
             "net{}kyori",
             "adventure-text-serializer-json",
             "4.25.0",
             "SCtKohjXyHn89X5dD5zATbS01LVnnrmbcn9hBO1/uYI=",
+            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
+            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             relocate("net{}kyori{}option", "kyori{}option"),
-            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE),
-            relocateIfNot("net{}kyori{}adventure{}text{}serializer{}json", "adventure{}text{}serializer{}json", LoaderFlag.RELOCATE_ADVENTURE)
+            relocate("net{}kyori{}adventure{}text{}serializer{}json", "adventure{}text{}serializer{}json")
     ),
     KYORI_EXAMINATION_API(
             "net{}kyori",
@@ -181,11 +179,7 @@ public enum Dependency {
     }
 
     private static OptionalRelocation relocateIf(String relocateFrom, String relocateTo, LoaderFlag flag) {
-        return new ConditionalRelocation(relocateFrom, relocateTo, flag, false);
-    }
-
-    private static OptionalRelocation relocateIfNot(String relocateFrom, String relocateTo, LoaderFlag flag) {
-        return new ConditionalRelocation(relocateFrom, relocateTo, flag, true);
+        return new ConditionalRelocation(relocateFrom, relocateTo, flag);
     }
 
     private static Relocation relocateInner(String relocateFrom, String relocateTo) {
@@ -201,11 +195,10 @@ public enum Dependency {
         private final String relocateFrom;
         private final String relocateTo;
         private final LoaderFlag flag;
-        private final boolean negate;
 
         @Override
         public Optional<Relocation> relocate(Set<LoaderFlag> loaderFlags) {
-            if (loaderFlags.contains(flag) != negate) {
+            if (loaderFlags.contains(flag)) {
                 return Optional.of(Dependency.relocateInner(relocateFrom, relocateTo));
             }
             return Optional.empty();

--- a/core/src/main/java/com/rexcantor64/triton/dependencies/Dependency.java
+++ b/core/src/main/java/com/rexcantor64/triton/dependencies/Dependency.java
@@ -16,16 +16,16 @@ public enum Dependency {
     ADVENTURE(
             "net{}kyori",
             "adventure-api",
-            "4.23.0",
-            "Ubn89img4yWTTyoyHpdL1tqCMzMmb/CZtK2GJC7cXvQ=",
+            "4.25.0",
+            "jigb8TV/+Rr5eDpsJCdrSD2BVKezyrWwTpCea/XnLJ0=",
             relocate("net{}kyori{}adventure", "adventure"),
             relocate("net{}kyori{}examination", "kyori{}examination")
     ),
     ADVENTURE_TEXT_SERIALIZER_GSON(
             "net{}kyori",
             "adventure-text-serializer-gson",
-            "4.23.0",
-            "PiaD2i0UAwMjzJZFu6TNhtfLq/zkK9Fi7C2lDF59Yig=",
+            "4.25.0",
+            "kx9nlZ1G4P5Vtkq5Fk4xtXi3kjV4f2nUcrYoZfl7ckU=",
             relocate("net{}kyori{}option", "kyori{}option"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
             relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE),
@@ -35,8 +35,8 @@ public enum Dependency {
     ADVENTURE_TEXT_SERIALIZER_LEGACY(
             "net{}kyori",
             "adventure-text-serializer-legacy",
-            "4.23.0",
-            "1SgOt1vypertB5eXGmzJAtxrjLtv6sJwEcyGJGEIIJ0=",
+            "4.25.0",
+            "BvFSXr8X+080w08bUmKt5nJwXBFj9qSLaKTgMU36ahM=",
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
             relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE),
             relocateIfNot("net{}kyori{}adventure{}text{}serializer{}legacy", "adventure{}text{}serializer{}legacy", LoaderFlag.RELOCATE_ADVENTURE)
@@ -44,8 +44,8 @@ public enum Dependency {
     ADVENTURE_TEXT_SERIALIZER_PLAIN(
             "net{}kyori",
             "adventure-text-serializer-plain",
-            "4.23.0",
-            "wuHYBMob54Q09K1r29U8yXoROtkpXLTJNs87nZAsWR4=",
+            "4.25.0",
+            "lFN1egpsDdnktfzSVOgqfqhn9MvkA3cWf0QMQexgUu4=",
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
             relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE),
             relocateIfNot("net{}kyori{}adventure{}text{}serializer{}plain", "adventure{}text{}serializer{}plain", LoaderFlag.RELOCATE_ADVENTURE)
@@ -53,7 +53,7 @@ public enum Dependency {
     ADVENTURE_TEXT_SERIALIZER_BUNGEECORD(
             "net{}kyori",
             "adventure-text-serializer-bungeecord",
-            "4.4.0",
+            "4.4.1",
             "4bw3bG3HohAAFgFXNc5MzFNNKya/WrgqrHUcUDIFbDk=",
             relocate("net{}kyori{}option", "kyori{}option"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
@@ -66,8 +66,8 @@ public enum Dependency {
     ADVENTURE_MINI_MESSAGE(
             "net{}kyori",
             "adventure-text-minimessage",
-            "4.23.0",
-            "Vu0nZroiOLQBuuqWDTquRftY/aFhTalo/iuR/bnDgTw=",
+            "4.25.0",
+            "GY8nxvkeXjJxZAZQhp/v3WgW17MQtIz6UptfWOSpKaQ=",
             relocate("net{}kyori{}option", "kyori{}option"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
             relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE),
@@ -81,16 +81,16 @@ public enum Dependency {
     ADVENTURE_KEY(
             "net{}kyori",
             "adventure-key",
-            "4.23.0",
-            "gDd4WEpb+PpfF7q5s7YkUO4TEP2SjyAPFoOSmkMMJmQ=",
+            "4.25.0",
+            "zsjwq/ZC3w5ie/Wp//bxfLtiDqb+BfIWK5bK0VZNiFc=",
             relocate("net{}kyori{}adventure", "adventure"),
             relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE)
     ),
     ADVENTURE_TEXT_SERIALIZER_JSON(
             "net{}kyori",
             "adventure-text-serializer-json",
-            "4.23.0",
-            "/CvHvwb8Cv5wbWJ493GDcqRoTSGhblLk1iJldxUomE8=",
+            "4.25.0",
+            "SCtKohjXyHn89X5dD5zATbS01LVnnrmbcn9hBO1/uYI=",
             relocate("net{}kyori{}option", "kyori{}option"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.RELOCATE_ADVENTURE),
             relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.RELOCATE_ADVENTURE),

--- a/core/src/main/java/com/rexcantor64/triton/dependencies/DependencyManager.java
+++ b/core/src/main/java/com/rexcantor64/triton/dependencies/DependencyManager.java
@@ -31,20 +31,5 @@ public class DependencyManager {
         libraryManager.addRepository(Repository.DIOGOTC_MIRROR);
         libraryManager.addMavenCentral();
         libraryManager.setRelocator(new NativeRelocationHelper());
-
-        if (hasLoaderFlag(LoaderFlag.SHADE_ADVENTURE)) {
-            if (hasLoaderFlag(LoaderFlag.RELOCATE_ADVENTURE)) {
-                loadDependency(Dependency.ADVENTURE);
-                loadDependency(Dependency.ADVENTURE_KEY);
-                loadDependency(Dependency.KYORI_EXAMINATION_API);
-                loadDependency(Dependency.KYORI_EXAMINATION_STRING);
-            }
-            loadDependency(Dependency.KYORI_OPTION);
-            loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_GSON);
-            loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_JSON);
-            loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_LEGACY);
-            loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_PLAIN);
-            loadDependency(Dependency.ADVENTURE_MINI_MESSAGE);
-        }
     }
 }

--- a/core/src/main/java/com/rexcantor64/triton/plugin/PluginLoader.java
+++ b/core/src/main/java/com/rexcantor64/triton/plugin/PluginLoader.java
@@ -1,8 +1,10 @@
 package com.rexcantor64.triton.plugin;
 
+import com.rexcantor64.triton.dependencies.Dependency;
 import com.rexcantor64.triton.dependencies.DependencyManager;
 import com.rexcantor64.triton.loader.utils.LoaderFlag;
 import com.rexcantor64.triton.logger.TritonLogger;
+import lombok.val;
 
 import java.io.InputStream;
 import java.util.Set;
@@ -19,4 +21,29 @@ public interface PluginLoader {
 
     Set<LoaderFlag> getLoaderFlags();
 
+    /**
+     * Load all adventure-related libraries according to the enabled loader flags.
+     *
+     * @since 4.0.0
+     */
+    default void loadAdventure() {
+        val depManager = getDependencyManager();
+        if (depManager.hasLoaderFlag(LoaderFlag.VENDOR_ADVENTURE)) {
+            depManager.loadDependency(Dependency.ADVENTURE);
+            depManager.loadDependency(Dependency.ADVENTURE_KEY);
+            depManager.loadDependency(Dependency.KYORI_EXAMINATION_API);
+            depManager.loadDependency(Dependency.KYORI_EXAMINATION_STRING);
+        }
+        if (depManager.hasLoaderFlag(LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS)) {
+            depManager.loadDependency(Dependency.KYORI_OPTION);
+            depManager.loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_GSON);
+            depManager.loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_JSON);
+            depManager.loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_LEGACY);
+            depManager.loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_PLAIN);
+            depManager.loadDependency(Dependency.ADVENTURE_MINI_MESSAGE);
+        }
+        if (depManager.hasLoaderFlag(LoaderFlag.VENDOR_ADVENTURE_BUNGEE_SERIALIZER)) {
+            depManager.loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_BUNGEECORD);
+        }
+    }
 }

--- a/core/src/main/java/com/rexcantor64/triton/utils/ComponentUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/ComponentUtils.java
@@ -47,7 +47,7 @@ public class ComponentUtils {
 
     static {
         val tritonInstance = Triton.get();
-        if (tritonInstance != null && tritonInstance.getLoader().getLoaderFlags().contains(LoaderFlag.SHADE_ADVENTURE)) {
+        if (tritonInstance != null && tritonInstance.getLoader().getLoaderFlags().contains(LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS)) {
             // use most compatible options if we shaded adventure
             GSON_SERIALIZER = GsonComponentSerializer.builder()
                     .options(JSONOptions.compatibility())

--- a/triton-bungeecord/build.gradle
+++ b/triton-bungeecord/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compileOnly 'net.md-5:bungeecord-api:1.21-R0.4-SNAPSHOT'
     compileOnly 'net.md-5:bungeecord-proxy:1.21-R0.4-SNAPSHOT'
 
-    compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.4.0'
+    compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.4.1'
 
     implementation 'com.rexcantor64:libby-bungee:2.0.0'
 

--- a/triton-bungeecord/loader/src/main/java/com/rexcantor64/triton/loader/BungeeLoader.java
+++ b/triton-bungeecord/loader/src/main/java/com/rexcantor64/triton/loader/BungeeLoader.java
@@ -17,8 +17,9 @@ public class BungeeLoader extends Plugin {
                 .bootstrapClassName(BOOTSTRAP_CLASS)
                 .constructorType(Plugin.class)
                 .constructorValue(this)
-                .flag(LoaderFlag.SHADE_ADVENTURE)
-                .flag(LoaderFlag.RELOCATE_ADVENTURE)
+                .flag(LoaderFlag.VENDOR_ADVENTURE)
+                .flag(LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS)
+                .flag(LoaderFlag.VENDOR_ADVENTURE_BUNGEE_SERIALIZER)
                 .build()
                 .loadUserLoaderFlags(this.getDataFolder().toPath())
                 .loadPlugin();

--- a/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/plugin/BungeePlugin.java
+++ b/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/plugin/BungeePlugin.java
@@ -37,7 +37,7 @@ public class BungeePlugin implements PluginLoader, LoaderBootstrap {
         this.dependencyManager = new DependencyManager(new BungeeLibraryManager(this.getPlugin()), loaderFlags);
 
         this.dependencyManager.init();
-        this.dependencyManager.loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_BUNGEECORD);
+        this.loadAdventure();
 
         new BungeeTriton(this).onEnable();
     }

--- a/triton-spigot/build.gradle
+++ b/triton-spigot/build.gradle
@@ -17,9 +17,9 @@ dependencies {
 
     compileOnly 'org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT'
 
-    compileOnly 'net.kyori:adventure-text-serializer-gson:4.23.0'
-    compileOnly 'net.kyori:adventure-text-serializer-legacy:4.23.0'
-    compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.4.0'
+    compileOnly 'net.kyori:adventure-text-serializer-gson:4.25.0'
+    compileOnly 'net.kyori:adventure-text-serializer-legacy:4.25.0'
+    compileOnly 'net.kyori:adventure-text-serializer-bungeecord:4.4.1'
 
     compileOnly 'com.comphenix.protocol:ProtocolLib:5.4.0-SNAPSHOT'
     compileOnly 'me.clip:placeholderapi:2.11.6'

--- a/triton-spigot/loader/src/main/java/com/rexcantor64/triton/loader/SpigotLoader.java
+++ b/triton-spigot/loader/src/main/java/com/rexcantor64/triton/loader/SpigotLoader.java
@@ -4,10 +4,7 @@ import com.rexcantor64.triton.loader.utils.CommonLoader;
 import com.rexcantor64.triton.loader.utils.LoaderBootstrap;
 import com.rexcantor64.triton.loader.utils.LoaderFlag;
 import lombok.val;
-import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
-
-import java.lang.reflect.InvocationTargetException;
 
 public class SpigotLoader extends JavaPlugin {
     private static final String PLATFORM_JAR_NAME = "triton-spigot.jarinjar";
@@ -22,12 +19,14 @@ public class SpigotLoader extends JavaPlugin {
                 .constructorType(JavaPlugin.class)
                 .constructorValue(this);
 
-        if (!isModernPaper()) {
-            builder.flag(LoaderFlag.SHADE_ADVENTURE);
-            if (shouldRelocateAdventure()) {
-                builder.flag(LoaderFlag.RELOCATE_ADVENTURE);
-            }
+        if (shouldVendorAdventure()) {
+            builder.flag(LoaderFlag.VENDOR_ADVENTURE);
+            builder.flag(LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS);
+        } else if (shouldVendorAdventureSerializers()) {
+            builder.flag(LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS);
         }
+        // paper does not include the bungee md5 library serializer
+        builder.flag(LoaderFlag.VENDOR_ADVENTURE_BUNGEE_SERIALIZER);
 
         this.plugin = builder
                 .build()
@@ -35,42 +34,33 @@ public class SpigotLoader extends JavaPlugin {
                 .loadPlugin();
     }
 
-    private boolean isModernPaper() {
+    private boolean shouldVendorAdventure() {
         try {
-            val server = Bukkit.getServer();
-            // this method is only available on Paper (and forks)
-            val method = server.getClass().getMethod("getMinecraftVersion");
-            String version = method.invoke(server).toString();
-
-            val parts = version.split("\\.");
-            val major = Integer.parseInt(parts[0]);
-            val minor = Integer.parseInt(parts[1]);
-            val patch = Integer.parseInt(parts[2]);
-
-            // Ensure at least Paper 1.21.4 (adventure 4.18, shadow color introduced)
-            val wantedMajor = 1;
-            val wantedMinor = 21;
-            val wantedPatch = 4;
-            return major > wantedMajor
-                    || (major == wantedMajor && minor > wantedMinor)
-                    || (major == wantedMajor && minor == wantedMinor && patch >= wantedPatch);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException |
-                 IndexOutOfBoundsException | NumberFormatException ignore) {
-            // Paper is not present or an outdated version is present
-            return false;
-        }
-    }
-
-    private boolean shouldRelocateAdventure() {
-        try {
-            // Method only available on adventure 4.22.0+
-            Class<?> clickEventClass = Class.forName("net.kyori.adventure.text.event.ClickEvent");
-            clickEventClass.getMethod("payload");
+            // Method only available on adventure 4.25.0+
+            // Finding a method instead of a class, since plugins can incorrectly shade newer versions than what is installed in the server
+            Class<?> clickEventClass = Class.forName("net.kyori.adventure.text.Component");
+            clickEventClass.getMethod("object");
 
             // A modern version of adventure is already present
             return false;
         } catch (ClassNotFoundException | NoSuchMethodException ignore) {
             // Adventure is not present or an outdated version is present
+            return true;
+        }
+    }
+
+    private boolean shouldVendorAdventureSerializers() {
+        try {
+            // Get a method from all the wanted packages
+            Class.forName("net.kyori.adventure.text.minimessage.MiniMessage");
+            Class.forName("net.kyori.adventure.text.serializer.gson.GsonComponentSerializer");
+            Class.forName("net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer");
+            Class.forName("net.kyori.adventure.text.serializer.plain.PlainComponentSerializer");
+
+            // A modern version of adventure serializers is already present
+            return false;
+        } catch (ClassNotFoundException ignore) {
+            // Adventure serializers are not present or outdated versions are present
             return true;
         }
     }

--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/plugin/SpigotPlugin.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/plugin/SpigotPlugin.java
@@ -35,7 +35,7 @@ public class SpigotPlugin implements PluginLoader, LoaderBootstrap {
         this.dependencyManager = new DependencyManager(new BukkitLibraryManager(this.getPlugin()), loaderFlags);
 
         this.dependencyManager.init();
-        this.dependencyManager.loadDependency(Dependency.ADVENTURE_TEXT_SERIALIZER_BUNGEECORD);
+        this.loadAdventure();
 
         new SpigotTriton(this).onEnable();
     }

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/plugin/VelocityPlugin.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/plugin/VelocityPlugin.java
@@ -64,6 +64,7 @@ public class VelocityPlugin implements PluginLoader, LoaderBootstrap {
     @Override
     public void onEnable() {
         getDependencyManager().init();
+        loadAdventure();
 
         new VelocityTriton(this).onEnable();
     }


### PR DESCRIPTION
This streamlines the relocation rules for adventure, which also fixes an issue where the bungeecord serializer wasn't correctly relocated.