### PR TITLE
feat(core): translate items with packetevents

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
@@ -14,6 +14,7 @@ import com.rexcantor64.triton.packetinterceptor.handlers.DeathScreenPacketHandle
 import com.rexcantor64.triton.packetinterceptor.handlers.DisconnectPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.EntityPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.GuiPacketHandler;
+import com.rexcantor64.triton.packetinterceptor.handlers.ItemPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.ResourcePackPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.ScoreboardPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.TabPacketHandler;
@@ -140,6 +141,13 @@ public class PacketEventsListener implements PacketListener {
             }
 
             updatedHandlers.put(PacketType.Play.Server.JOIN_GAME, entityHandler::onJoinGame);
+        }
+        if (config.isItems()) {
+            val itemHandler = new ItemPacketHandler(parser, config);
+            updatedHandlers.put(PacketType.Play.Server.SET_CURSOR_ITEM, itemHandler::onSetCursorItemPacket);
+            updatedHandlers.put(PacketType.Play.Server.SET_PLAYER_INVENTORY, itemHandler::onSetPlayerInventoryPacket);
+            updatedHandlers.put(PacketType.Play.Server.SET_SLOT, itemHandler::onSetSlotPacket);
+            updatedHandlers.put(PacketType.Play.Server.WINDOW_ITEMS, itemHandler::onWindowItemsPacket);
         }
 
         receiveHandlers = Collections.unmodifiableMap(updatedHandlers);

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
@@ -1,6 +1,7 @@
 package com.rexcantor64.triton.packetinterceptor;
 
 import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.event.UserDisconnectEvent;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
@@ -40,7 +41,8 @@ import java.util.stream.Collectors;
  */
 public class PacketEventsListener implements PacketListener {
 
-    private Map<PacketTypeCommon, BiConsumer<PacketSendEvent, TritonLanguagePlayer<?>>> receiveHandlers = Collections.emptyMap();
+    private Map<PacketTypeCommon, BiConsumer<PacketSendEvent, TritonLanguagePlayer<?>>> sendHandlers = Collections.emptyMap();
+    private Map<PacketTypeCommon, BiConsumer<PacketReceiveEvent, TritonLanguagePlayer<?>>> receiveHandlers = Collections.emptyMap();
 
     /**
      * Setup handlers according to what is enabled on config.
@@ -51,6 +53,7 @@ public class PacketEventsListener implements PacketListener {
         val parser = Triton.get().getMessageParser();
         val config = Triton.get().getConfig();
         val updatedHandlers = new HashMap<PacketTypeCommon, BiConsumer<PacketSendEvent, TritonLanguagePlayer<?>>>();
+        val updatedReceiveHandlers = new HashMap<PacketTypeCommon, BiConsumer<PacketReceiveEvent, TritonLanguagePlayer<?>>>();
 
         // parse allowed entity types from config
         val allowedEntities = config.getAllowedEntityTypes().stream()
@@ -118,7 +121,7 @@ public class PacketEventsListener implements PacketListener {
             updatedHandlers.put(PacketType.Play.Server.COMBAT_EVENT, deathScreenHandler::onCombatEventPacket);
             updatedHandlers.put(PacketType.Play.Server.DEATH_COMBAT_EVENT, deathScreenHandler::onDeathCombatEventPacket);
         }
-        if (config.isGuis()) {
+        if (config.isGuis() || config.isItems()) {
             val guiHandler = new GuiPacketHandler(parser, config);
             updatedHandlers.put(PacketType.Play.Server.OPEN_WINDOW, guiHandler::onOpenWindowPacket);
         }
@@ -148,13 +151,27 @@ public class PacketEventsListener implements PacketListener {
             updatedHandlers.put(PacketType.Play.Server.SET_PLAYER_INVENTORY, itemHandler::onSetPlayerInventoryPacket);
             updatedHandlers.put(PacketType.Play.Server.SET_SLOT, itemHandler::onSetSlotPacket);
             updatedHandlers.put(PacketType.Play.Server.WINDOW_ITEMS, itemHandler::onWindowItemsPacket);
+            updatedHandlers.put(PacketType.Play.Server.CLOSE_WINDOW, itemHandler::onServerCloseWindowPacket);
+            updatedReceiveHandlers.put(PacketType.Play.Client.CLOSE_WINDOW, itemHandler::onClientCloseWindowPacket);
         }
 
-        receiveHandlers = Collections.unmodifiableMap(updatedHandlers);
+        sendHandlers = Collections.unmodifiableMap(updatedHandlers);
+        receiveHandlers = Collections.unmodifiableMap(updatedReceiveHandlers);
     }
 
     @Override
     public void onPacketSend(PacketSendEvent event) {
+        val type = event.getPacketType();
+
+        val handler = sendHandlers.get(type);
+        if (handler != null) {
+            val languagePlayer = Triton.get().getPlayerManager().get(event.getUser().getUUID());
+            handler.accept(event, languagePlayer);
+        }
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
         val type = event.getPacketType();
 
         val handler = receiveHandlers.get(type);

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/GuiPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/GuiPacketHandler.java
@@ -15,24 +15,34 @@ public class GuiPacketHandler {
 
     private final @NotNull MessageParser parser;
     private final @NotNull MainConfig.FeatureSyntax syntax;
+    private final boolean translateGuiTitles;
+    private final boolean translateItems;
 
     public GuiPacketHandler(@NotNull MessageParser parser, @NotNull MainConfig config) {
         this.parser = parser;
         this.syntax = config.getGuiSyntax();
+        this.translateGuiTitles = config.isGuis();
+        this.translateItems = config.isItems();
     }
 
     public void onOpenWindowPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
         val packet = new WrapperPlayServerOpenWindow(event);
 
-        parser.translateComponent(
-                        packet.getTitle(),
-                        languagePlayer,
-                        syntax
-                )
-                .getResultOrToRemove(Component::empty)
-                .ifPresent(result -> {
-                    packet.setTitle(result);
-                    event.markForReEncode(true);
-                });
+        if (this.translateItems) {
+            languagePlayer.getPacketEventsRefresh().setCurrentWindowId(packet.getContainerId());
+        }
+
+        if (translateGuiTitles) {
+            parser.translateComponent(
+                            packet.getTitle(),
+                            languagePlayer,
+                            syntax
+                    )
+                    .getResultOrToRemove(Component::empty)
+                    .ifPresent(result -> {
+                        packet.setTitle(result);
+                        event.markForReEncode(true);
+                    });
+        }
     }
 }

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ItemPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ItemPacketHandler.java
@@ -1,0 +1,77 @@
+package com.rexcantor64.triton.packetinterceptor.handlers;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetCursorItem;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetPlayerInventory;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetSlot;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerWindowItems;
+import com.rexcantor64.triton.config.MainConfig;
+import com.rexcantor64.triton.language.parser.MessageParser;
+import com.rexcantor64.triton.player.TritonLanguagePlayer;
+import com.rexcantor64.triton.utils.ItemStackTranslationUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.jetbrains.annotations.NotNull;
+
+@RequiredArgsConstructor
+public class ItemPacketHandler {
+
+    private final ItemStackTranslationUtils itemHandler;
+
+    public ItemPacketHandler(@NotNull MessageParser parser, @NotNull MainConfig config) {
+        this.itemHandler = new ItemStackTranslationUtils(parser, config.getItemsSyntax());
+    }
+
+    public void onSetCursorItemPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerSetCursorItem(event);
+
+        val result = this.itemHandler.translateItem(packet.getStack(), languagePlayer);
+        if (result.isModified()) {
+            packet.setStack(result.getModified());
+            event.markForReEncode(true);
+        }
+    }
+
+    public void onSetPlayerInventoryPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerSetPlayerInventory(event);
+
+        val result = this.itemHandler.translateItem(packet.getStack(), languagePlayer);
+        if (result.isModified()) {
+            packet.setStack(result.getModified());
+            event.markForReEncode(true);
+        }
+    }
+
+    public void onSetSlotPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerSetSlot(event);
+
+        val result = this.itemHandler.translateItem(packet.getItem(), languagePlayer);
+        if (result.isModified()) {
+            packet.setItem(result.getModified());
+            event.markForReEncode(true);
+        }
+    }
+
+    public void onWindowItemsPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        val packet = new WrapperPlayServerWindowItems(event);
+
+        val carriedItem = packet.getCarriedItem();
+        if (carriedItem.isPresent()) {
+            val result = this.itemHandler.translateItem(carriedItem.get(), languagePlayer);
+            if (result.isModified()) {
+                packet.setCarriedItem(result.getModified());
+                event.markForReEncode(true);
+            }
+        }
+
+        val windowItems = packet.getItems();
+        for (int i = 0; i < windowItems.size(); i++) {
+            val item = windowItems.get(i);
+            val result = this.itemHandler.translateItem(item, languagePlayer);
+            if (result.isModified()) {
+                windowItems.set(i, result.getModified());
+                event.markForReEncode(true);
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ItemPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ItemPacketHandler.java
@@ -1,5 +1,6 @@
 package com.rexcantor64.triton.packetinterceptor.handlers;
 
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetCursorItem;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetPlayerInventory;
@@ -73,5 +74,13 @@ public class ItemPacketHandler {
                 event.markForReEncode(true);
             }
         }
+    }
+
+    public void onClientCloseWindowPacket(@NotNull PacketReceiveEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        languagePlayer.getPacketEventsRefresh().setCurrentWindowId(0);
+    }
+
+    public void onServerCloseWindowPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
+        languagePlayer.getPacketEventsRefresh().setCurrentWindowId(0);
     }
 }

--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ItemPacketHandler.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/handlers/ItemPacketHandler.java
@@ -18,13 +18,19 @@ import org.jetbrains.annotations.NotNull;
 public class ItemPacketHandler {
 
     private final ItemStackTranslationUtils itemHandler;
+    private final boolean translateInventoryItems;
 
     public ItemPacketHandler(@NotNull MessageParser parser, @NotNull MainConfig config) {
         this.itemHandler = new ItemStackTranslationUtils(parser, config.getItemsSyntax());
+        this.translateInventoryItems = config.isInventoryItems();
     }
 
     public void onSetCursorItemPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
         val packet = new WrapperPlayServerSetCursorItem(event);
+
+        if (!this.translateInventoryItems && languagePlayer.getPacketEventsRefresh().getCurrentWindowId() == 0) {
+            return;
+        }
 
         val result = this.itemHandler.translateItem(packet.getStack(), languagePlayer);
         if (result.isModified()) {
@@ -36,6 +42,10 @@ public class ItemPacketHandler {
     public void onSetPlayerInventoryPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
         val packet = new WrapperPlayServerSetPlayerInventory(event);
 
+        if (!this.translateInventoryItems && languagePlayer.getPacketEventsRefresh().getCurrentWindowId() == 0) {
+            return;
+        }
+
         val result = this.itemHandler.translateItem(packet.getStack(), languagePlayer);
         if (result.isModified()) {
             packet.setStack(result.getModified());
@@ -46,6 +56,10 @@ public class ItemPacketHandler {
     public void onSetSlotPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
         val packet = new WrapperPlayServerSetSlot(event);
 
+        if (!this.translateInventoryItems && languagePlayer.getPacketEventsRefresh().getCurrentWindowId() == 0) {
+            return;
+        }
+
         val result = this.itemHandler.translateItem(packet.getItem(), languagePlayer);
         if (result.isModified()) {
             packet.setItem(result.getModified());
@@ -55,6 +69,10 @@ public class ItemPacketHandler {
 
     public void onWindowItemsPacket(@NotNull PacketSendEvent event, @NotNull TritonLanguagePlayer<?> languagePlayer) {
         val packet = new WrapperPlayServerWindowItems(event);
+
+        if (!this.translateInventoryItems && languagePlayer.getPacketEventsRefresh().getCurrentWindowId() == 0) {
+            return;
+        }
 
         val carriedItem = packet.getCarriedItem();
         if (carriedItem.isPresent()) {

--- a/core/src/main/java/com/rexcantor64/triton/player/PacketEventsRefresh.java
+++ b/core/src/main/java/com/rexcantor64/triton/player/PacketEventsRefresh.java
@@ -12,6 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.UserProfile;
 import com.github.retrooper.packetevents.protocol.score.ScoreFormat;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientClickWindow;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBossBar;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDestroyEntities;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityHeadLook;
@@ -29,6 +30,7 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTe
 import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.config.MainConfig;
 import com.rexcantor64.triton.language.parser.MessageParser;
+import com.rexcantor64.triton.utils.ItemStackTranslationUtils;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -39,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +62,13 @@ public class PacketEventsRefresh {
     private final Map<Integer, Entity> entityMap = new ConcurrentHashMap<>();
     private final Map<UUID, Player> tentativePlayerMap = new ConcurrentHashMap<>();
     private final Map<Integer, Player> spawnedPlayerMap = new ConcurrentHashMap<>();
+
+    /**
+     * The window ID of the currently open window.
+     * If no window is open, this must be set to 0, which corresponds to the player's inventory.
+     */
+    @Setter
+    private int currentWindowId = 0;
 
     private final TritonLanguagePlayer<?> languagePlayer;
 
@@ -333,6 +343,10 @@ public class PacketEventsRefresh {
             val syntax = cfg.getTabSyntax();
             updatePlayerListHeaderFooter(user, syntax, parser);
             updatePlayerList(user, syntax, parser);
+        }
+        if (cfg.isItems()) {
+            val handler = new ItemStackTranslationUtils(parser, cfg.getItemsSyntax());
+            updateInventoryItems(user, handler);
         }
     }
 
@@ -642,6 +656,15 @@ public class PacketEventsRefresh {
                 player.getPitch(),
                 new ArrayList<>()
         );
+    }
+
+    private void updateInventoryItems(@NotNull User user, @NotNull ItemStackTranslationUtils handler) {
+        if (user.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_17_1)) {
+            // Here we use a hack where we pretend to the server that the client is out-of-sync (i.e., incorrect stateId),
+            // making it resend the entire window contents
+            val packet = new WrapperPlayClientClickWindow(this.currentWindowId, -1, 0, Byte.MAX_VALUE, WrapperPlayClientClickWindow.WindowClickType.PICKUP, Collections.emptyMap(), Optional.empty());
+            user.receivePacketSilently(packet);
+        }
     }
 
     @RequiredArgsConstructor

--- a/core/src/main/java/com/rexcantor64/triton/player/PacketEventsRefresh.java
+++ b/core/src/main/java/com/rexcantor64/triton/player/PacketEventsRefresh.java
@@ -68,6 +68,7 @@ public class PacketEventsRefresh {
      * If no window is open, this must be set to 0, which corresponds to the player's inventory.
      */
     @Setter
+    @Getter
     private int currentWindowId = 0;
 
     private final TritonLanguagePlayer<?> languagePlayer;

--- a/core/src/main/java/com/rexcantor64/triton/utils/ItemStackTranslationUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/ItemStackTranslationUtils.java
@@ -1,0 +1,195 @@
+package com.rexcantor64.triton.utils;
+
+import com.github.retrooper.packetevents.protocol.component.ComponentTypes;
+import com.github.retrooper.packetevents.protocol.component.builtin.item.ItemContainerContents;
+import com.github.retrooper.packetevents.protocol.component.builtin.item.ItemLore;
+import com.github.retrooper.packetevents.protocol.component.builtin.item.WrittenBookContent;
+import com.github.retrooper.packetevents.protocol.item.ItemStack;
+import com.github.retrooper.packetevents.util.Filterable;
+import com.rexcantor64.triton.api.language.Localized;
+import com.rexcantor64.triton.config.MainConfig;
+import com.rexcantor64.triton.language.parser.MessageParser;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class ItemStackTranslationUtils {
+
+    private final @NotNull MessageParser parser;
+    private final @NotNull MainConfig.FeatureSyntax syntax;
+
+    public ModifiableItemStack translateItem(ItemStack item, Localized locale) {
+        val modifiableItem = new ModifiableItemStack(item);
+        this.translateItem(modifiableItem, locale, true, true);
+        return modifiableItem;
+    }
+
+    private void translateItem(ModifiableItemStack item, Localized locale, boolean translateLore, boolean translateBook) {
+        translateItemName(item, locale);
+        translateCustomName(item, locale);
+        if (translateLore) {
+            translateLore(item, locale);
+            translateContainerContents(item, locale);
+        }
+        if (translateBook) {
+            translateBook(item, locale);
+        }
+    }
+
+    private void translateItemName(ModifiableItemStack item, Localized locale) {
+        val itemNameOpt = item.getOriginal().getComponent(ComponentTypes.ITEM_NAME);
+        if (!itemNameOpt.isPresent()) {
+            return;
+        }
+
+        val itemName = itemNameOpt.get();
+        parser.translateComponent(
+                        itemName,
+                        locale,
+                        this.syntax
+                )
+                .map(ComponentUtils::ensureNotItalic)
+                .ifChanged(result -> item.willModify().setComponent(ComponentTypes.ITEM_NAME, result))
+                .ifToRemove(() -> item.willModify().unsetComponent(ComponentTypes.ITEM_NAME));
+    }
+
+    private void translateCustomName(ModifiableItemStack item, Localized locale) {
+        val itemNameOpt = item.getOriginal().getComponent(ComponentTypes.CUSTOM_NAME);
+        if (!itemNameOpt.isPresent()) {
+            return;
+        }
+
+        val itemName = itemNameOpt.get();
+        parser.translateComponent(
+                        itemName,
+                        locale,
+                        this.syntax
+                )
+                .map(ComponentUtils::ensureNotItalic)
+                .ifChanged(result -> item.willModify().setComponent(ComponentTypes.CUSTOM_NAME, result))
+                .ifToRemove(() -> item.willModify().unsetComponent(ComponentTypes.CUSTOM_NAME));
+    }
+
+    private void translateLore(ModifiableItemStack item, Localized locale) {
+        val loreOpt = item.getOriginal().getComponent(ComponentTypes.LORE);
+        if (!loreOpt.isPresent()) {
+            return;
+        }
+
+        val lore = loreOpt.get();
+        AtomicBoolean loreChanged = new AtomicBoolean(false);
+        List<Component> newLines = new ArrayList<>();
+        for (Component line : lore.getLines()) {
+            parser.translateComponent(
+                            line,
+                            locale,
+                            this.syntax
+                    )
+                    .map(ComponentUtils::splitByNewLine)
+                    .ifChanged(result -> {
+                        newLines.addAll(
+                                result.stream()
+                                        .map(ComponentUtils::ensureNotItalic)
+                                        .collect(Collectors.toList())
+                        );
+                        loreChanged.set(true);
+                    })
+                    .ifUnchanged(() -> newLines.add(line))
+                    .ifToRemove(() -> loreChanged.set(true));
+        }
+        if (!loreChanged.get()) {
+            return;
+        }
+        item.willModify().setComponent(ComponentTypes.LORE, new ItemLore(newLines));
+    }
+
+    private void translateContainerContents(ModifiableItemStack item, Localized locale) {
+        val containerContentsOpt = item.getOriginal().getComponent(ComponentTypes.CONTAINER);
+        if (!containerContentsOpt.isPresent()) {
+            return;
+        }
+
+        boolean contentsChanged = false;
+        val containerContents = containerContentsOpt.get();
+        val newContents = new ArrayList<ItemStack>(containerContents.getItems().size());
+        for (val itemStack : containerContents.getItems()) {
+            val modifiableItem = new ModifiableItemStack(itemStack);
+            translateItem(modifiableItem, locale, false, false);
+            if (modifiableItem.isModified()) {
+                newContents.add(modifiableItem.getModified());
+                contentsChanged = true;
+            } else {
+                newContents.add(itemStack);
+            }
+        }
+
+        if (contentsChanged) {
+            item.willModify().setComponent(ComponentTypes.CONTAINER, new ItemContainerContents(newContents));
+        }
+    }
+
+    private void translateBook(ModifiableItemStack item, Localized locale) {
+        val bookContentOpt = item.getOriginal().getComponent(ComponentTypes.WRITTEN_BOOK_CONTENT);
+        if (!bookContentOpt.isPresent()) {
+            return;
+        }
+
+        boolean contentsChanged = false;
+        val bookContent = bookContentOpt.get();
+        val newPages = new ArrayList<Filterable<@NotNull Component>>(bookContent.getPages().size());
+        for (val page : bookContent.getPages()) {
+            val translationResult = parser.translateComponent(
+                    page.getRaw(),
+                    locale,
+                    syntax
+            );
+            translationResult
+                    .ifChanged(result -> {
+                        newPages.add(new Filterable<>(result, page.getFiltered()));
+                    })
+                    .ifUnchanged(() -> newPages.add(page));
+            contentsChanged |= !translationResult.isUnchanged();
+        }
+
+        if (contentsChanged) {
+            item.willModify().setComponent(
+                    ComponentTypes.WRITTEN_BOOK_CONTENT,
+                    new WrittenBookContent(
+                            bookContent.getTitle(),
+                            bookContent.getAuthor(),
+                            bookContent.getGeneration(),
+                            newPages,
+                            bookContent.isResolved()
+                    )
+            );
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class ModifiableItemStack {
+        private final @NotNull ItemStack original;
+        private @Nullable ItemStack modified = null;
+
+        public boolean isModified() {
+            return this.modified != null;
+        }
+
+        public @NotNull ItemStack willModify() {
+            if (this.modified == null) {
+                this.modified = this.original.copy();
+            }
+            return this.modified;
+        }
+    }
+
+}


### PR DESCRIPTION
- [x] Translation
- [x] Refresh (on 1.17.1+ only for now)
- [ ] ~~Handle creative mode~~ (not in scope for this PR, ProtocolLib implementation also doesn't have it)

Relates to #503 