### PR TITLE
fix(bungee): clear cached bossbars when switching servers

### DIFF
--- a/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/listeners/BungeeListener.java
+++ b/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/listeners/BungeeListener.java
@@ -1,10 +1,10 @@
 package com.rexcantor64.triton.bungeecord.listeners;
 
 import com.rexcantor64.triton.Triton;
-import com.rexcantor64.triton.bungeecord.utils.BaseComponentUtils;
 import com.rexcantor64.triton.bungeecord.BungeeTriton;
 import com.rexcantor64.triton.bungeecord.packetinterceptor.PreLoginBungeeEncoder;
 import com.rexcantor64.triton.bungeecord.player.BungeeLanguagePlayer;
+import com.rexcantor64.triton.bungeecord.utils.BaseComponentUtils;
 import com.rexcantor64.triton.utils.ReflectionUtils;
 import com.rexcantor64.triton.utils.SocketUtils;
 import io.netty.channel.Channel;
@@ -20,6 +20,7 @@ import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.event.EventHandler;
 import net.md_5.bungee.event.EventPriority;
 import net.md_5.bungee.netty.PipelineUtils;
+import net.md_5.bungee.protocol.ProtocolConstants;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -34,6 +35,14 @@ public class BungeeListener implements Listener {
         Triton.get().getLogger().logTrace("Player %1 connected to a new server", lp);
 
         BungeeTriton.asBungee().getBridgeManager().sendPlayerLanguage(lp, event.getServer());
+
+        if (event.getPlayer().getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_20_2) {
+            // On 1.20.2 and above, the join player packet starts clearing bossbars automatically, so clear them here
+            lp.clearCachedBossbars();
+            if (Triton.get().getConfig().isUsePacketEvents()) {
+                lp.getPacketEventsRefresh().discardAllBossBars();
+            }
+        }
 
         if (Triton.get().getConfig().isRunLanguageCommandsOnLogin()) {
             lp.executeCommands(event.getServer());

--- a/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/player/BungeeLanguagePlayer.java
+++ b/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/player/BungeeLanguagePlayer.java
@@ -79,6 +79,10 @@ public class BungeeLanguagePlayer extends TritonLanguagePlayer<ProxiedPlayer> {
         bossBars.remove(uuid);
     }
 
+    public void clearCachedBossbars() {
+        bossBars.clear();
+    }
+
     public void setLastTabHeader(BaseComponent lastTabHeader) {
         this.lastTabHeader = lastTabHeader.duplicate();
     }

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/listeners/VelocityListener.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/listeners/VelocityListener.java
@@ -52,8 +52,8 @@ public class VelocityListener {
             val lp = (VelocityLanguagePlayer) Triton.get().getPlayerManager().get(e.getPlayer().getUniqueId());
             VelocityTriton.asVelocity().getBridgeManager().sendPlayerLanguage(lp);
 
-            if (lp.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_20_3) > 0) {
-                // On 1.20.6 and above, the notchian client crashes if a bossbar that does not exist client-side is updated
+            if (lp.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_2)) {
+                // On 1.20.2 and above, the join player packet starts clearing bossbars automatically, so clear them here
                 lp.clearCachedBossbars();
                 if (Triton.get().getConfig().isUsePacketEvents()) {
                     lp.getPacketEventsRefresh().discardAllBossBars();


### PR DESCRIPTION
Relates to https://github.com/tritonmc/Triton/issues/439