### PR TITLE
[backport v3] fix(bungee): clear cached bossbars when switching servers

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/listeners/BungeeListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/listeners/BungeeListener.java
@@ -17,6 +17,7 @@ import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.event.EventHandler;
 import net.md_5.bungee.event.EventPriority;
 import net.md_5.bungee.netty.PipelineUtils;
+import net.md_5.bungee.protocol.ProtocolConstants;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -32,6 +33,11 @@ public class BungeeListener implements Listener {
         Triton.get().getLogger().logTrace("Player %1 connected to a new server", lp);
 
         Triton.asBungee().getBridgeManager().sendPlayerLanguage(lp, event.getServer());
+
+        if (event.getPlayer().getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_20_2) {
+            // On 1.20.2 and above, the join player packet starts clearing bossbars automatically, so clear them here
+            lp.clearCachedBossbars();
+        }
 
         if (Triton.get().getConf().isRunLanguageCommandsOnLogin()) {
             lp.executeCommands(event.getServer());

--- a/core/src/main/java/com/rexcantor64/triton/player/BungeeLanguagePlayer.java
+++ b/core/src/main/java/com/rexcantor64/triton/player/BungeeLanguagePlayer.java
@@ -69,6 +69,10 @@ public class BungeeLanguagePlayer implements LanguagePlayer {
         bossBars.remove(uuid);
     }
 
+    public void clearCachedBossbars() {
+        bossBars.clear();
+    }
+
     public void setLastTabHeader(BaseComponent lastTabHeader) {
         this.lastTabHeader = lastTabHeader.duplicate();
     }


### PR DESCRIPTION
Backport of:
- https://github.com/tritonmc/Triton/pull/560