### PR TITLE
chore: update packetevents to 2.11.0

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compileOnly 'org.apache.logging.log4j:log4j-core:2.17.1'
     compileOnly 'org.yaml:snakeyaml:2.0'
 
-    compileOnly 'com.github.retrooper:packetevents-api:2.10.0'
+    compileOnly 'com.github.retrooper:packetevents-api:2.11.0'
 
     implementation 'org.slf4j:slf4j-nop:1.7.36'
     implementation 'com.zaxxer:HikariCP:4.0.3'

--- a/core/src/main/java/com/rexcantor64/triton/dependencies/Dependency.java
+++ b/core/src/main/java/com/rexcantor64/triton/dependencies/Dependency.java
@@ -120,8 +120,8 @@ public enum Dependency {
     PACKET_EVENTS_API(
             "com{}github{}retrooper",
             "packetevents-api",
-            "2.10.0",
-            "pdaW/xrw13MT9H0xnJez9+WNmafRApdijp34njZ05n4=",
+            "2.11.0",
+            "pQyAMZnDXD/8LgXUVMZHnj8JnK5fSqUX5vo4LbGfVhk=",
             relocate("com{}github{}retrooper{}packetevents", "packetevents{}api"),
             relocate("io{}github{}retrooper{}packetevents", "packetevents{}impl"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
@@ -135,8 +135,8 @@ public enum Dependency {
     PACKET_EVENTS_NETTY_COMMON(
             "com{}github{}retrooper",
             "packetevents-netty-common",
-            "2.10.0",
-            "3WafAPe9IXICdUgbffRMpAq4zj3LniwNkO/XfnZAX+g=",
+            "2.11.0",
+            "vfNwOO63rASjVdj0pv0N402IgoZ2SYsP4+fZmA+B3oA=",
             relocate("com{}github{}retrooper{}packetevents", "packetevents{}api"),
             relocate("io{}github{}retrooper{}packetevents", "packetevents{}impl"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
@@ -150,8 +150,8 @@ public enum Dependency {
     PACKET_EVENTS_SPIGOT(
             "com{}github{}retrooper",
             "packetevents-spigot",
-            "2.10.0",
-            "DFb6juVlnwbbNIvGYUXDIRfjXFWQ+isuU/iVuwn56Yw=",
+            "2.11.0",
+            "jPQ9vf8uaAW2UFHpqQda/5WoQGoj5XwbPNxJnlrg9IQ=",
             relocate("com{}github{}retrooper{}packetevents", "packetevents{}api"),
             relocate("io{}github{}retrooper{}packetevents", "packetevents{}impl"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
@@ -165,8 +165,8 @@ public enum Dependency {
     PACKET_EVENTS_VELOCITY(
             "com{}github{}retrooper",
             "packetevents-velocity",
-            "2.10.0",
-            "EUbMnX9enkzYbdduoc+KS/3FjbCke0i4ZvMAQHjLFXY=",
+            "2.11.0",
+            "5tJzbBjyoWMIAhTcL9hMtmKVg8m91in8vrnkK1aOVns=",
             relocate("com{}github{}retrooper{}packetevents", "packetevents{}api"),
             relocate("io{}github{}retrooper{}packetevents", "packetevents{}impl"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),

--- a/triton-spigot/build.gradle
+++ b/triton-spigot/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compileOnly 'com.comphenix.protocol:ProtocolLib:5.4.0-SNAPSHOT'
     compileOnly 'me.clip:placeholderapi:2.11.6'
 
-    compileOnly 'com.github.retrooper:packetevents-spigot:2.10.0'
+    compileOnly 'com.github.retrooper:packetevents-spigot:2.11.0'
 
     // Libraries available on Spigot
     compileOnly 'org.fusesource.jansi:jansi:2.4.0' // Used for terminal translation

--- a/triton-velocity/build.gradle
+++ b/triton-velocity/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
     implementation 'org.bstats:bstats-velocity:3.1.0'
 
-    compileOnly 'com.github.retrooper:packetevents-velocity:2.10.0'
+    compileOnly 'com.github.retrooper:packetevents-velocity:2.11.0'
 }
 
 shadowJar {


### PR DESCRIPTION
https://github.com/retrooper/packetevents/releases/tag/v2.11.0