### PR TITLE
fix: load adventure-nbt when shading adventure

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compileOnly('net.kyori:adventure-text-minimessage:4.25.0') {
         exclude group: 'net.kyori', module: 'adventure-api'
         exclude group: 'net.kyori', module: 'adventure-key'
+        exclude group: 'net.kyori', module: 'adventure-nbt'
         exclude group: 'net.kyori', module: 'adventure-text-serialize-gson'
         exclude group: 'net.kyori', module: 'adventure-text-serialize-legacy'
         exclude group: 'net.kyori', module: 'adventure-text-serialize-plain'

--- a/core/src/main/java/com/rexcantor64/triton/dependencies/Dependency.java
+++ b/core/src/main/java/com/rexcantor64/triton/dependencies/Dependency.java
@@ -84,6 +84,14 @@ public enum Dependency {
             relocate("net{}kyori{}adventure", "adventure"),
             relocate("net{}kyori{}examination", "kyori{}examination")
     ),
+    ADVENTURE_NBT(
+            "net{}kyori",
+            "adventure-nbt",
+            "4.25.0",
+            "jubaYh9JbxbGGd5uxcC5wUDOrJuJwqWzN3k429VaFi4=",
+            relocate("net{}kyori{}adventure", "adventure"),
+            relocate("net{}kyori{}examination", "kyori{}examination")
+    ),
     ADVENTURE_TEXT_SERIALIZER_JSON(
             "net{}kyori",
             "adventure-text-serializer-json",

--- a/core/src/main/java/com/rexcantor64/triton/plugin/PluginLoader.java
+++ b/core/src/main/java/com/rexcantor64/triton/plugin/PluginLoader.java
@@ -31,6 +31,7 @@ public interface PluginLoader {
         if (depManager.hasLoaderFlag(LoaderFlag.VENDOR_ADVENTURE)) {
             depManager.loadDependency(Dependency.ADVENTURE);
             depManager.loadDependency(Dependency.ADVENTURE_KEY);
+            depManager.loadDependency(Dependency.ADVENTURE_NBT);
             depManager.loadDependency(Dependency.KYORI_EXAMINATION_API);
             depManager.loadDependency(Dependency.KYORI_EXAMINATION_STRING);
         }


### PR DESCRIPTION
adventure-nbt is a dependency of packetevents and is included in adventure-bom.