### PR TITLE
fix(core): order of end delimiters on serialized component

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/language/parser/LegacyParser.java
+++ b/core/src/main/java/com/rexcantor64/triton/language/parser/LegacyParser.java
@@ -18,8 +18,6 @@ import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.TranslationArgument;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
-import net.kyori.adventure.text.flattener.ComponentFlattener;
-import net.kyori.adventure.text.flattener.FlattenerListener;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.ShadowColor;
 import net.kyori.adventure.text.format.Style;
@@ -736,6 +734,17 @@ public class LegacyParser extends MessageParser {
                 this.linkBugStyle = null;
                 val i = this.topIndex--;
 
+                // The order needs to be the reverse of pushStyle
+                @Nullable val font = style.font();
+                if (font != null && (i == 0 || !font.equals(this.stack[i - 1].font()))) {
+                    this.stringBuilder.append(FONT_END_DELIM);
+                }
+
+                @Nullable val hoverEvent = style.hoverEvent();
+                if (hoverEvent != null && (i == 0 || !hoverEvent.equals(this.stack[i - 1].hoverEvent()))) {
+                    this.stringBuilder.append(HOVER_END_DELIM);
+                }
+
                 @Nullable val clickEvent = style.clickEvent();
                 if (clickEvent != null && (i == 0 || !clickEvent.equals(this.stack[i - 1].clickEvent()))) {
                     // See comment on linkBugStyle
@@ -744,16 +753,6 @@ public class LegacyParser extends MessageParser {
                     } else {
                         this.linkBugStyle = this.stack[i].clickEvent(null);
                     }
-                }
-
-                @Nullable val hoverEvent = style.hoverEvent();
-                if (hoverEvent != null && (i == 0 || !hoverEvent.equals(this.stack[i - 1].hoverEvent()))) {
-                    this.stringBuilder.append(HOVER_END_DELIM);
-                }
-
-                @Nullable val font = style.font();
-                if (font != null && (i == 0 || !font.equals(this.stack[i - 1].font()))) {
-                    this.stringBuilder.append(FONT_END_DELIM);
                 }
             }
 

--- a/core/src/test/java/com/rexcantor64/triton/language/parser/LegacyParserTest.java
+++ b/core/src/test/java/com/rexcantor64/triton/language/parser/LegacyParserTest.java
@@ -441,4 +441,28 @@ public class LegacyParserTest {
 
         assertEquals(TranslationResult.ResultState.TO_REMOVE, result.getState());
     }
+
+    @Test
+    public void testParseComponentWithClickAndHoverAndFontInSameComponent() {
+        Component comp = Component.text()
+                .content("[lang]without.formatting[/lang]")
+                .hoverEvent(HoverEvent.showText(Component.text("hover")))
+                .clickEvent(ClickEvent.copyToClipboard("click"))
+                .font(Key.key("testing:testing"))
+                .asComponent();
+
+        TranslationResult<Component> result = parser.translateComponent(new SerializedComponent(comp), configuration)
+                .map(SerializedComponent::toComponent);
+
+        Component expected = Component.text()
+                .content("This is text without formatting")
+                .hoverEvent(HoverEvent.showText(Component.text("hover")))
+                .clickEvent(ClickEvent.copyToClipboard("click"))
+                .font(Key.key("testing:testing"))
+                .asComponent();
+
+        assertEquals(TranslationResult.ResultState.CHANGED, result.getState());
+        assertNotNull(result.getResultRaw());
+        assertEquals(expected.compact(), result.getResultRaw().compact());
+    }
 }


### PR DESCRIPTION
Previously, the delimiters were incorrectly nested, leading to components with both click and hover (or font) to throw a string index out of bounds exception when deserializing.