### PR TITLE
fix(core): disable minimsg compacting on legacy parser

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/language/TranslationManager.java
+++ b/core/src/main/java/com/rexcantor64/triton/language/TranslationManager.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -180,6 +181,8 @@ public class TranslationManager implements com.rexcantor64.triton.api.language.T
                                     .resolvers(TagResolver.standard())
                                     .tag("triton", this.createTritonMiniMessageTagHandler(language))
                                     .build())
+                            // avoid compacting due to legacy parser needing full style information
+                            .postProcessor(UnaryOperator.identity())
                             .build();
                     this.miniMessageInstances.put(language, miniMessage);
                 });


### PR DESCRIPTION
When a translation uses MiniMessage and has identical sequential styles, that information is lost during compacting, so converting to a SerializedComponent yields an incorrect representation of the user's intent.
For example, translation `<red>Lorem %1 <red>Ipsum` was being converted to `§cLorem %1 Ipsum` instead of `§cLorem %1 §cIpsum`.

Disabling the compacting step resolves this issue.