### PR TITLE
refactor: deprecate syntax-args on config

### DIFF
--- a/api/src/main/java/com/rexcantor64/triton/api/config/FeatureSyntax.java
+++ b/api/src/main/java/com/rexcantor64/triton/api/config/FeatureSyntax.java
@@ -19,7 +19,10 @@ public interface FeatureSyntax {
      * Default is "args".
      * @return The key of the tag that starts/end the variables of a placeholder
      * @since 1.0.0
+     * @deprecated The [args] tag is no longer needed as of Triton v4.0.0.
+     * Simply using the [arg] tags without surrounding them with [args].
      */
+    @Deprecated
     String getArgs();
 
     /**

--- a/config_chinese.yml
+++ b/config_chinese.yml
@@ -123,32 +123,28 @@ storage:
     #  verifyServerCertificate: false
 
 # 这里你可以关闭一些插件的功能
-# 每个选项都包含"syntax-lang", "syntax-args" 和 "syntax-arg"三个字符. 这用于变量.
+# 每个选项都包含"syntax-lang" 和 "syntax-arg"三个字符. 这用于变量.
 # 如果更改了变量,也需在其他翻译了的插件配置文件中更改.
 language-creation:
   chat:
     # 需替换聊天中的变量吗?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   actionbars:
     # 需替换Actionbar中的变量吗?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   titles:
     # 需替换题目标题中的变量吗?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   guis:
     # 需替换gui中的变量吗?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   holograms:
     # 需替换全息悬浮字中的变量吗 (或实体名)?
@@ -160,19 +156,16 @@ language-creation:
     # 当开启此选项 将忽略types选项 并检查/替换所有实体名
     allow-all: false
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   kick:
     # 需替换kick信息中的变量吗?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   tab:
     # 需替换tab中的变量吗?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   items:
     # 需替换物品名中的变量吗?
@@ -184,19 +177,16 @@ language-creation:
     # 若要翻译书请开启上面的 "allow-in-inventory" 选项
     books: false
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   signs:
     # 插件是否需要将木牌上的语言替换为 languages.json?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   bossbars:
     # 需替换boss条中的变量吗? (1.9+)
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   motd:
     # 插件需替换 MOTD 中的变量吗?
@@ -204,7 +194,6 @@ language-creation:
     # 若IP地区为未知地区,则将使用主语言
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   scoreboards:
     # Should the plugin check for placeholders in scoreboard teams and objectives?
@@ -213,7 +202,6 @@ language-creation:
     # To translate scoreboards, it is recommended to translate using PlaceholderAPI
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   # 若含以下消息的变量将不会发送给玩家(控制台仍可接受).
   # 不填写则为关闭此功能 (默认为关闭).

--- a/core/src/main/java/com/rexcantor64/triton/config/MainConfig.java
+++ b/core/src/main/java/com/rexcantor64/triton/config/MainConfig.java
@@ -340,6 +340,7 @@ public class MainConfig implements TritonConfig {
     @VisibleForTesting
     public static class FeatureSyntax implements com.rexcantor64.triton.api.config.FeatureSyntax {
         private final String lang;
+        @Deprecated
         private final String args;
         private final String arg;
         @ToString.Exclude

--- a/triton-bungeecord/src/main/resources/config_bungeecord.yml
+++ b/triton-bungeecord/src/main/resources/config_bungeecord.yml
@@ -127,44 +127,38 @@ experimental-use-packetevents: false
 message-parser: "adventure"
 
 # Here you can enable and disable certain features of the plugin.
-# Every section contains a "syntax-lang", "syntax-args" and "syntax-arg" field. These are used in the placeholders.
+# Every section contains a "syntax-lang" and "syntax-arg" field. These are used in the placeholders.
 # If you change them, make sure to adjust accordingly in your plugins.
 language-creation:
   chat:
     # Should the plugin check for placeholders in chat messages?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   actionbars:
     # Should the plugin check for placeholders in action bars?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   titles:
     # Should the plugin check for placeholders in titles and subtitles?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   kick:
     # Should the plugin check for placeholders in kick messages?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   tab:
     # Should the plugin check for placeholders in tab?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   bossbars:
     # Should the plugin check for placeholders in bossbars? (1.9+)
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   motd:
     # Should the plugin check for placeholders in the MOTD?
@@ -172,7 +166,6 @@ language-creation:
     # When the IP is unknown, the default language is used.
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   scoreboards:
     # Should the plugin check for placeholders in scoreboard teams and objectives?
@@ -181,7 +174,6 @@ language-creation:
     # To translate scoreboards, it is recommended to translate using PlaceholderAPI
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   # If any message contains a placeholder with the key defined in the field below, that message won't be sent to the players (console will still receive it).
   # Leave empty to disable this feature (it's disabled by default).

--- a/triton-spigot/src/main/resources/config_spigot.yml
+++ b/triton-spigot/src/main/resources/config_spigot.yml
@@ -146,7 +146,7 @@ experimental-use-packetevents: false
 message-parser: "adventure"
 
 # Here you can enable and disable certain features of the plugin.
-# Every section contains a "syntax-lang", "syntax-args" and "syntax-arg" field. These are used in the placeholders.
+# Every section contains a "syntax-lang" and "syntax-arg" field. These are used in the placeholders.
 # If you change them, make sure to adjust accordingly in your plugins.
 language-creation:
   chat:
@@ -155,25 +155,21 @@ language-creation:
     # Should the plugin check for placeholders in signed chat messages (MC 1.19+)? Requires the above option to be enabled as well.
     signed-enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   actionbars:
     # Should the plugin check for placeholders in action bars?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   titles:
     # Should the plugin check for placeholders in titles and subtitles?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   guis:
     # Should the plugin check for placeholders in GUIs' titles?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   holograms:
     # Should the plugin check for placeholders in holograms (and/or entity display names)?
@@ -188,19 +184,16 @@ language-creation:
     # When enabled, the list above is ignored and all entities' names are checked and translated.
     allow-all: false
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   kick:
     # Should the plugin check for placeholders in kick messages?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   tab:
     # Should the plugin check for placeholders in tab?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   items:
     # Should the plugin check for placeholders in items?
@@ -212,19 +205,16 @@ language-creation:
     # It is recommended to enable "allow-in-inventory" above if this is enabled.
     books: false
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   signs:
     # Should the plugin overlay the signs with the translations on languages.json?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   bossbars:
     # Should the plugin check for placeholders in bossbars? (1.9+)
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   motd:
     # Should the plugin check for placeholders in the MOTD?
@@ -232,7 +222,6 @@ language-creation:
     # When the IP is unknown, the default language is used.
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   scoreboards:
     # Should the plugin check for placeholders in scoreboard teams and objectives?
@@ -241,7 +230,6 @@ language-creation:
     # To translate scoreboards, it is recommended to translate using PlaceholderAPI
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   advancements:
     # Should the plugin check for placeholders in advancements?
@@ -249,7 +237,6 @@ language-creation:
     # This is intended for plugins that add custom advancements, since Minecraft's default advancements are already translated.
     enabled: false
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
     # EXPERIMENTAL: Should the advancements be refreshed when the language changes?
     # There might be some issues with this enabled, disable if you have those issues.
@@ -260,13 +247,11 @@ language-creation:
     # Only works on 1.9 and above.
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   resource-pack-prompt:
     # Should the plugin translate the prompt for Resource Pack requests? (1.17+)
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   # If any message contains a placeholder with the key defined in the field below, that message won't be sent to the players (console will still receive it).
   # Leave empty to disable this feature (it's disabled by default).

--- a/triton-velocity/src/main/resources/config_velocity.yml
+++ b/triton-velocity/src/main/resources/config_velocity.yml
@@ -127,7 +127,7 @@ experimental-use-packetevents: false
 message-parser: "adventure"
 
 # Here you can enable and disable certain features of the plugin.
-# Every section contains a "syntax-lang", "syntax-args" and "syntax-arg" field. These are used in the placeholders.
+# Every section contains a "syntax-lang" and "syntax-arg" field. These are used in the placeholders.
 # If you change them, make sure to adjust accordingly in your plugins.
 language-creation:
   chat:
@@ -136,25 +136,21 @@ language-creation:
     # Should the plugin check for placeholders in signed chat messages (MC 1.19+)? Requires the above option to be enabled as well.
     signed-enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   actionbars:
     # Should the plugin check for placeholders in action bars?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   titles:
     # Should the plugin check for placeholders in titles and subtitles?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   guis:
     # Should the plugin check for placeholders in GUIs' titles?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   holograms:
     # Should the plugin check for placeholders in holograms (and/or entity display names)?
@@ -169,19 +165,16 @@ language-creation:
     # When enabled, the list above is ignored and all entities' names are checked and translated.
     allow-all: false
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   kick:
     # Should the plugin check for placeholders in kick messages?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   tab:
     # Should the plugin check for placeholders in tab?
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   items:
     # Should the plugin check for placeholders in items?
@@ -193,13 +186,11 @@ language-creation:
     # It is recommended to enable "allow-in-inventory" above if this is enabled.
     books: false
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   bossbars:
     # Should the plugin check for placeholders in bossbars? (1.9+)
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   motd:
     # Should the plugin check for placeholders in the MOTD?
@@ -207,7 +198,6 @@ language-creation:
     # When the IP is unknown, the default language is used.
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   scoreboards:
     # Should the plugin check for placeholders in scoreboard teams and objectives?
@@ -216,20 +206,17 @@ language-creation:
     # To translate scoreboards, it is recommended to translate using PlaceholderAPI
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   death-screen:
     # Should the plugin check for placeholders in the death screen (shown when the player dies)?
     # Only works on 1.9 and above.
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   resource-pack-prompt:
     # Should the plugin translate the prompt for Resource Pack requests? (1.17+)
     enabled: true
     syntax-lang: lang
-    syntax-args: args
     syntax-arg: arg
   # If any message contains a placeholder with the key defined in the field below, that message won't be sent to the players (console will still receive it).
   # Leave empty to disable this feature (it's disabled by default).


### PR DESCRIPTION
As of Triton v4, the [args] tag is no longer needed on Triton placeholders, so it has been removed from the default config. The syntax-args option continues to be read if it exists, and placeholders containing the [args] tag will continue to work as-is.