### PR TITLE
refactor: use minimessage tag as placeholder in messages config

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/commands/DebugCommand.java
+++ b/core/src/main/java/com/rexcantor64/triton/commands/DebugCommand.java
@@ -10,6 +10,7 @@ import com.rexcantor64.triton.commands.handler.exceptions.UnsupportedPlatformExc
 import com.rexcantor64.triton.debug.LoadDump;
 import com.rexcantor64.triton.utils.DebugUtils;
 import lombok.val;
+import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -159,10 +160,10 @@ public class DebugCommand implements Command {
                     }
                     if (action.get() == DumpAction.ADD) {
                         dumpManager.enableForPlayer(player, types);
-                        sendMessage(event, "debug.dump.success.add.player", typeNamesStr, player);
+                        sendMessage(event, "debug.dump.success.add.player", typeNamesStr, player.toString());
                     } else {
                         dumpManager.disableForPlayer(player, types);
-                        sendMessage(event, "debug.dump.success.remove.player", typeNamesStr, player);
+                        sendMessage(event, "debug.dump.success.remove.player", typeNamesStr, player.toString());
                     }
                 }
                 break;
@@ -212,7 +213,7 @@ public class DebugCommand implements Command {
                 sender.sendMessage(message);
             }
 
-            sendMessage(event, "debug.load.success.sent", messages.size());
+            sendMessage(event, "debug.load.success.sent", Integer.toString(messages.size()));
         } catch (IOException e) {
             sendMessage(event, "debug.load.dump-file.not-found", dumpName, e.getMessage());
             Triton.get().getLogger().logError(e, "Failed to open dump file");
@@ -301,11 +302,11 @@ public class DebugCommand implements Command {
      * @param code  The code of the message to send
      * @param args  The arguments of the message
      */
-    private void sendMessage(CommandEvent event, String code, Object... args) {
+    private void sendMessage(CommandEvent event, String code, String... args) {
         event.getSender().sendMessageFormatted(
                 "debug.prefix",
-                event.getPlatform(),
-                Triton.get().getMessagesConfig().getMessageUnsafe(code, args)
+                Component.text(event.getPlatform().toString()),
+                Triton.get().getMessagesConfig().getMessageComponent(code, Arrays.stream(args).map(Component::text).toArray(Component[]::new))
         );
     }
 

--- a/core/src/main/java/com/rexcantor64/triton/commands/HelpCommand.java
+++ b/core/src/main/java/com/rexcantor64/triton/commands/HelpCommand.java
@@ -7,10 +7,10 @@ import com.rexcantor64.triton.commands.handler.CommandHandler;
 import com.rexcantor64.triton.commands.handler.exceptions.NoPermissionException;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import net.kyori.adventure.text.Component;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class HelpCommand implements Command {
@@ -24,10 +24,15 @@ public class HelpCommand implements Command {
         val commands = commandHandler.getAvailableCommands()
                 .stream()
                 .map(name -> {
-                    val description = Triton.get().getMessagesConfig().getMessageUnsafe("command." + name);
-                    return Triton.get().getMessagesConfig().getMessageUnsafe("help.menu-item", event.getLabel(), name, description);
+                    val description = Triton.get().getMessagesConfig().getMessageComponent("command." + name);
+                    return Triton.get().getMessagesConfig().getMessageComponent(
+                            "help.menu-item",
+                            Component.text(event.getLabel()),
+                            Component.text(name),
+                            description
+                    );
                 })
-                .collect(Collectors.joining("<reset><newline>"));
+                .collect(Component.toComponent(Component.newline()));
         event.getSender().sendMessageFormatted("help.menu", commands);
     }
 

--- a/core/src/main/java/com/rexcantor64/triton/commands/TwinCommand.java
+++ b/core/src/main/java/com/rexcantor64/triton/commands/TwinCommand.java
@@ -10,6 +10,7 @@ import com.rexcantor64.triton.web.TwinParser;
 import com.rexcantor64.triton.web.exceptions.NotOnProxyException;
 import lombok.val;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -83,7 +84,8 @@ public class TwinCommand implements Command {
             }
 
             if (!downloading) {
-                sender.sendMessageFormatted("twin.uploaded", TwinManager.getBaseUrl() + "/" + response.getPage());
+                val link = TwinManager.getBaseUrl() + "/" + response.getPage();
+                sender.sendMessageFormatted("twin.uploaded", Component.text().content(link).clickEvent(ClickEvent.openUrl(link)));
                 return;
             }
 

--- a/core/src/main/java/com/rexcantor64/triton/commands/TwinCommand.java
+++ b/core/src/main/java/com/rexcantor64/triton/commands/TwinCommand.java
@@ -9,6 +9,7 @@ import com.rexcantor64.triton.web.TwinManager;
 import com.rexcantor64.triton.web.TwinParser;
 import com.rexcantor64.triton.web.exceptions.NotOnProxyException;
 import lombok.val;
+import net.kyori.adventure.text.Component;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -73,11 +74,10 @@ public class TwinCommand implements Command {
 
             if (response.getStatusCode() != 200) {
                 sender.sendMessageFormatted(downloading ? "twin.failed-fetch" : "twin.failed-upload", Triton.get()
-                        .getMessagesConfig().getMessageUnsafe("twin.incorrect-status", response.getStatusCode()));
+                        .getMessagesConfig().getMessageComponent("twin.incorrect-status", Component.text(response.getStatusCode())));
                 if (response.getStatusCode() == 404) {
                     // Warn people that accidentally type "/twin reload" instead of "/triton reload" for example
                     sender.sendMessageFormatted("twin.suggestion-wrong-command", "/triton " + event.argumentsToString());
-
                 }
                 return;
             }

--- a/core/src/main/java/com/rexcantor64/triton/commands/handler/Sender.java
+++ b/core/src/main/java/com/rexcantor64/triton/commands/handler/Sender.java
@@ -2,8 +2,10 @@ package com.rexcantor64.triton.commands.handler;
 
 import com.rexcantor64.triton.commands.handler.exceptions.NoPermissionException;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
 import java.util.UUID;
 
 public interface Sender {
@@ -13,7 +15,16 @@ public interface Sender {
 
     void sendMessage(Component component);
 
-    void sendMessageFormatted(String code, Object... args);
+    default void sendMessageFormatted(String code, Object... args) {
+        this.sendMessageFormatted(code, Arrays.stream(args).map(obj -> {
+            if (obj instanceof ComponentLike) {
+                return (ComponentLike) obj;
+            }
+            return Component.text(obj.toString());
+        }).toArray(ComponentLike[]::new));
+    }
+
+    void sendMessageFormatted(String code, ComponentLike... args);
 
     void assertPermission(@NotNull String permission) throws NoPermissionException;
 

--- a/core/src/main/java/com/rexcantor64/triton/config/MessagesConfig.java
+++ b/core/src/main/java/com/rexcantor64/triton/config/MessagesConfig.java
@@ -6,8 +6,12 @@ import com.rexcantor64.triton.config.interfaces.YamlConfiguration;
 import com.rexcantor64.triton.utils.YAMLUtils;
 import lombok.val;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
@@ -46,20 +50,19 @@ public class MessagesConfig {
         return Objects.toString(msg, "Unknown message");
     }
 
-    private String getMessage(String code, Object... args) {
+    private String getMessage(String code, int argsLength) {
         String s = getString(code);
-        for (int i = 0; i < args.length; i++)
-            if (args[i] != null)
-                s = s.replace("%" + (i + 1), args[i].toString());
+        for (int i = 0; i < argsLength; i++)
+            s = s.replace("%" + (i + 1), "<arg" + i + ">");
         return s;
     }
 
-    public String getMessageUnsafe(String code, Object... args) {
-        return this.getMessage(code, args);
-    }
-
-    public Component getMessageComponent(String code, Object... args) {
-        String msg = getMessage(code, args);
-        return MiniMessage.miniMessage().deserialize(msg);
+    public Component getMessageComponent(String code, ComponentLike... args) {
+        String msg = getMessage(code, args.length);
+        val resolvers = new TagResolver[args.length];
+        for (int i = 0; i < args.length; i++) {
+            resolvers[i] = Placeholder.component("arg" + i, args[i]);
+        }
+        return MiniMessage.miniMessage().deserialize(msg, resolvers);
     }
 }

--- a/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/commands/handler/BungeeSender.java
+++ b/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/commands/handler/BungeeSender.java
@@ -6,6 +6,7 @@ import com.rexcantor64.triton.commands.handler.Sender;
 import com.rexcantor64.triton.commands.handler.exceptions.NoPermissionException;
 import lombok.AllArgsConstructor;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -30,7 +31,7 @@ public class BungeeSender implements Sender {
     }
 
     @Override
-    public void sendMessageFormatted(String code, Object... args) {
+    public void sendMessageFormatted(String code, ComponentLike... args) {
         sendMessage(Triton.get().getMessagesConfig().getMessageComponent(code, args));
     }
 

--- a/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/player/BungeeLanguagePlayer.java
+++ b/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/player/BungeeLanguagePlayer.java
@@ -136,7 +136,7 @@ public class BungeeLanguagePlayer extends TritonLanguagePlayer<ProxiedPlayer> {
         this.language = event.getNewLanguage();
         if (this.waitingForClientLocale && getParent() != null)
             parent.sendMessage(BaseComponentUtils.serialize(Triton.get().getMessagesConfig()
-                    .getMessageComponent("success.detected-language", language.getDisplayName())));
+                    .getMessageComponent("success.detected-language", ((com.rexcantor64.triton.language.Language) language).getDisplayNameComponent())));
         this.waitingForClientLocale = false;
 
         if (sendToSpigot && getParent() != null)

--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/SpigotTriton.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/SpigotTriton.java
@@ -209,7 +209,7 @@ public class SpigotTriton extends Triton<SpigotLanguagePlayer, SpigotBridgeManag
                     languagePlayer.setLang(lang);
                     player.closeInventory();
                     player.spigot().sendMessage(BaseComponentUtils.serialize(Triton.get().getMessagesConfig()
-                            .getMessageComponent("success.selector", lang.getDisplayName())));
+                            .getMessageComponent("success.selector", ((Language) lang).getDisplayNameComponent())));
                 }));
             }
             gui.open(player);

--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/commands/handler/SpigotSender.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/commands/handler/SpigotSender.java
@@ -6,6 +6,7 @@ import com.rexcantor64.triton.commands.handler.exceptions.NoPermissionException;
 import com.rexcantor64.triton.spigot.utils.BaseComponentUtils;
 import lombok.AllArgsConstructor;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -29,7 +30,7 @@ public class SpigotSender implements Sender {
     }
 
     @Override
-    public void sendMessageFormatted(String code, Object... args) {
+    public void sendMessageFormatted(String code, ComponentLike... args) {
         sendMessage(Triton.get().getMessagesConfig().getMessageComponent(code, args));
     }
 

--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/guiapi/ScrollableGui.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/guiapi/ScrollableGui.java
@@ -130,7 +130,7 @@ public class ScrollableGui extends Gui {
         stackMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         stackMeta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE);
         stackMeta.setDisplayName(LegacyComponentSerializer.legacySection().serialize(Triton.get().getMessagesConfig()
-                .getMessageComponent("other.selector-gui-currentpage", page, getMaxPages())));
+                .getMessageComponent("other.selector-gui-currentpage", Component.text(page), Component.text(getMaxPages()))));
         infoButton.setItemMeta(stackMeta);
         inv.setItem(49, infoButton);
     }

--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/player/SpigotLanguagePlayer.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/player/SpigotLanguagePlayer.java
@@ -135,7 +135,7 @@ public class SpigotLanguagePlayer extends TritonLanguagePlayer<Player> {
             try {
                 if (toBukkit().isPresent()) {
                     bukkit.spigot().sendMessage(BaseComponentUtils.serialize(
-                            Triton.get().getMessagesConfig().getMessageComponent("success.detected-language", lang.getDisplayName())
+                            Triton.get().getMessagesConfig().getMessageComponent("success.detected-language", ((com.rexcantor64.triton.language.Language) lang).getDisplayNameComponent())
                     ));
                 } else {
                     Triton.get().getLogger()

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/commands/handler/VelocitySender.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/commands/handler/VelocitySender.java
@@ -7,6 +7,7 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import lombok.AllArgsConstructor;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,7 +31,7 @@ public class VelocitySender implements Sender {
     }
 
     @Override
-    public void sendMessageFormatted(String code, Object... args) {
+    public void sendMessageFormatted(String code, ComponentLike... args) {
         sendMessage(Triton.get().getMessagesConfig().getMessageComponent(code, args));
     }
 

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/player/VelocityLanguagePlayer.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/player/VelocityLanguagePlayer.java
@@ -128,7 +128,7 @@ public class VelocityLanguagePlayer extends TritonLanguagePlayer<Player> {
         this.language = language;
         if (this.waitingForClientLocale) {
             player.ifPresent(parent -> parent.sendMessage(Triton.get().getMessagesConfig()
-                    .getMessageComponent("success.detected-language", language.getDisplayName())));
+                    .getMessageComponent("success.detected-language", ((com.rexcantor64.triton.language.Language) language).getDisplayNameComponent())));
         }
         this.waitingForClientLocale = false;
 
@@ -177,7 +177,7 @@ public class VelocityLanguagePlayer extends TritonLanguagePlayer<Player> {
             this.waitingForClientLocale = false;
             this.language = Triton.get().getLanguageManager().getLanguageByLocaleOrDefault(this.clientLocale);
             player.ifPresent(parent -> parent.sendMessage(Triton.get().getMessagesConfig()
-                    .getMessageComponent("success.detected-language", language.getDisplayName())));
+                    .getMessageComponent("success.detected-language", ((com.rexcantor64.triton.language.Language) language).getDisplayNameComponent())));
         }
         player.ifPresent(parent -> Triton.get().getStorage()
                 .setLanguage(null, SocketUtils.getIpAddress(parent.getRemoteAddress()), language));


### PR DESCRIPTION
Converts %1, %2, ... into <arg0>, <arg1>, ... automatically.

Fixes https://github.com/tritonmc/Triton/issues/605