### PR TITLE
chore(nix): handle empty hash of dependency

### DIFF
--- a/build-support/gen-libby-zip.nix
+++ b/build-support/gen-libby-zip.nix
@@ -25,7 +25,7 @@ let
       inherit version;
       src = pkgs.fetchurl {
         url = "${repository}/${jarPath}";
-        hash = "sha256-${sha256Checksum}";
+        hash = lib.optionalString (sha256Checksum != "") "sha256-${sha256Checksum}";
       };
 
       dontUnpack = true;


### PR DESCRIPTION
This allows using Nix to get the new hashes easily.