### PR TITLE
fix: skip packetevents refresh when connection state != PLAY

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/player/PacketEventsRefresh.java
+++ b/core/src/main/java/com/rexcantor64/triton/player/PacketEventsRefresh.java
@@ -1,6 +1,7 @@
 package com.rexcantor64.triton.player;
 
 import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
@@ -315,13 +316,35 @@ public class PacketEventsRefresh {
      */
     public void refreshAll() {
         val playerOpt = this.languagePlayer.getPlatformPlayer();
-        if (!playerOpt.isPresent()) {
+        if (playerOpt.isEmpty()) {
+            Triton.get().getLogger().logDebug(
+                    "Skipped refreshing features for player %1 because could not get the platform's player instance",
+                    this.languagePlayer.getUUID()
+            );
             return;
         }
         val player = playerOpt.get();
         val user = PacketEvents.getAPI().getPlayerManager().getUser(player);
         val parser = Triton.get().getMessageParser();
         val cfg = Triton.get().getConfig();
+
+        if (user == null) {
+            Triton.get().getLogger().logDebug(
+                    "Skipped refreshing features for player %1 because could not get a PacketEvents user instance",
+                    this.languagePlayer.getUUID()
+            );
+            return;
+        }
+
+        if (user.getEncoderState() != ConnectionState.PLAY) {
+            // We cannot send these packets if the connection is not in the PLAY state.
+            // Doing so causes the client to throw an error and disconnect.
+            Triton.get().getLogger().logDebug(
+                    "Skipped refreshing features for player %1 because the connection is not in the play phase",
+                    this.languagePlayer.getUUID()
+            );
+            return;
+        }
 
         if (cfg.isBossbars()) {
             val syntax = cfg.getBossbarSyntax();

--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/player/SpigotLanguagePlayer.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/player/SpigotLanguagePlayer.java
@@ -177,32 +177,28 @@ public class SpigotLanguagePlayer extends TritonLanguagePlayer<Player> {
     public void refreshAll() {
         super.refreshAll();
         Triton.get().runAsync(() -> toBukkit().ifPresent(player -> {
-            refreshEntities();
-            refreshSigns();
-            player.updateInventory();
             getInterceptor().ifPresent((interceptor) -> {
-                if (Triton.get().getConfig().isTab() && lastTabHeader != null && lastTabFooter != null)
+                if (!Triton.get().getConfig().getAllowedEntityTypes().isEmpty() || Triton.get().getConfig().isHologramsAll()) {
+                    interceptor.refreshEntities(this);
+                }
+                if (Triton.get().getConfig().isSigns()) {
+                    interceptor.refreshSigns(this);
+                }
+                player.updateInventory();
+                if (Triton.get().getConfig().isTab() && lastTabHeader != null && lastTabFooter != null) {
                     interceptor.refreshTabHeaderFooter(this, lastTabHeader, lastTabFooter);
-                if (Triton.get().getConfig().isBossbars())
-                    for (Map.Entry<UUID, String> entry : bossBars.entrySet())
+                }
+                if (Triton.get().getConfig().isBossbars()) {
+                    for (Map.Entry<UUID, String> entry : bossBars.entrySet()) {
                         interceptor.refreshBossbar(this, entry.getKey(), entry.getValue());
-                if (Triton.get().getConfig().isScoreboards())
+                    }
+                }
+                if (Triton.get().getConfig().isScoreboards()) {
                     interceptor.refreshScoreboard(this);
+                }
                 interceptor.refreshAdvancements(this);
             });
         }));
-    }
-
-    private void refreshSigns() {
-        if (!Triton.get().getConfig().isSigns())
-            return;
-        getInterceptor().ifPresent(interceptor -> interceptor.refreshSigns(this));
-    }
-
-    private void refreshEntities() {
-        if (Triton.get().getConfig().getHolograms().size() == 0 && !Triton.get().getConfig().isHologramsAll())
-            return;
-        getInterceptor().ifPresent(interceptor -> interceptor.refreshEntities(this));
     }
 
     /**

--- a/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/player/VelocityLanguagePlayer.java
+++ b/triton-velocity/src/main/java/com/rexcantor64/triton/velocity/player/VelocityLanguagePlayer.java
@@ -47,13 +47,17 @@ public class VelocityLanguagePlayer extends TritonLanguagePlayer<Player> {
     private final Map<UUID, Component> playerListItemCache = new ConcurrentHashMap<>();
     private boolean waitingForClientLocale = false;
     private String clientLocale;
-    private final RefreshFeatures refresher;
+    private final @Nullable RefreshFeatures refresher;
 
     public VelocityLanguagePlayer(@NotNull UUID uuid) {
         super();
         Objects.requireNonNull(uuid, "cannot build VelocityLanguagePlayer from null UUID");
         this.uuid = uuid;
-        this.refresher = new RefreshFeatures(this);
+        if (Triton.get().getConfig().isUsePacketEvents()) {
+            this.refresher = null;
+        } else {
+            this.refresher = new RefreshFeatures(this);
+        }
         Triton.get().runAsync(this::load);
     }
 
@@ -143,7 +147,9 @@ public class VelocityLanguagePlayer extends TritonLanguagePlayer<Player> {
 
     public void refreshAll() {
         super.refreshAll();
-        this.refresher.refreshAll();
+        if (this.refresher != null) {
+            this.refresher.refreshAll();
+        }
     }
 
     public void injectNettyPipeline() {


### PR DESCRIPTION
A refresh is triggered during the first join due to Triton's language auto detection. When using the PacketEvents implementation, Triton attempts to send PLAY packets during the CONFIGURATION state, which causes the client to disconnect.

This commit fixes this issue by ignoring any refresh attempts when the connection state is not PLAY.

Fixes #617
Fixes #467

PS: credits to @patrikkoudelka for finding the root cause in https://github.com/patrikkoudelka/Triton/commit/e0a1dd97194ce531e766e7f7eeadbba03179cf00