### PR TITLE
refactor: remove slf4j-nop

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 
     compileOnly libs.bstats.base
 
-    implementation libs.slf4j.nop
     implementation libs.hikari
     implementation(libs.jsonpatch) {
         exclude group: 'com.google.code.gson', module: 'gson'

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -53,7 +53,6 @@ packetevents-spigot = { group = "com.github.retrooper", name = "packetevents-spi
 packetevents-velocity = { group = "com.github.retrooper", name = "packetevents-velocity", version.ref = "packetevents" }
 placeholderapi = { group = "me.clip", name = "placeholderapi", version = "2.12.3" }
 protocollib = { group = "com.comphenix.protocol", name = "ProtocolLib", version = "5.4.0-SNAPSHOT" }
-slf4j-nop = { group = "org.slf4j", name = "slf4j-nop", version = "1.7.36" }
 snakeyaml = { group = "org.yaml", name = "snakeyaml", version = "2.6" }
 spigot-api = { group = "org.spigotmc", name = "spigot-api", version.ref = "spigot" }
 spigot-legacy = { group = "org.spigotmc", name = "spigot-api", version = "1.8.8-R0.1-SNAPSHOT" }


### PR DESCRIPTION
Does not appear to be needed anymore to suppress the warning reported in #117.