### PR TITLE
fix(packetevents): infer uuid from LOGIN_START packet

### DIFF
--- a/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
+++ b/core/src/main/java/com/rexcantor64/triton/packetinterceptor/PacketEventsListener.java
@@ -7,6 +7,7 @@ import com.github.retrooper.packetevents.event.UserDisconnectEvent;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
+import com.github.retrooper.packetevents.wrapper.login.client.WrapperLoginClientLoginStart;
 import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.packetinterceptor.handlers.ActionBarPacketHandler;
 import com.rexcantor64.triton.packetinterceptor.handlers.BossBarPacketHandler;
@@ -173,14 +174,26 @@ public class PacketEventsListener implements PacketListener {
 
         val handler = sendHandlers.get(type);
         if (handler != null) {
-            val languagePlayer = Triton.get().getPlayerManager().get(event.getUser().getUUID());
-            handler.accept(event, languagePlayer);
+            val uuid = event.getUser().getUUID();
+            if (uuid != null) {
+                val languagePlayer = Triton.get().getPlayerManager().get(uuid);
+                handler.accept(event, languagePlayer);
+            }
         }
     }
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         val type = event.getPacketType();
+
+        if (type == PacketType.Login.Client.LOGIN_START) {
+            val packet = new WrapperLoginClientLoginStart(event);
+            packet.getPlayerUUID().ifPresent(uuid -> {
+                event.getUser().getProfile().setUUID(uuid);
+                val languagePlayer = Triton.get().getPlayerManager().get(event.getUser().getUUID());
+                languagePlayer.increaseConnectionCount();
+            });
+        }
 
         val handler = receiveHandlers.get(type);
         if (handler != null) {
@@ -193,8 +206,13 @@ public class PacketEventsListener implements PacketListener {
     public void onUserDisconnect(UserDisconnectEvent event) {
         // force language player to be unregistered
         val uuid = event.getUser().getUUID();
-        if (uuid != null) {
-            Triton.get().getPlayerManager().unregisterPlayer(uuid);
+        val playerManager = Triton.get().getPlayerManager();
+        if (uuid != null && playerManager.hasPlayer(uuid)) {
+            val lp = playerManager.get(event.getUser().getUUID());
+            lp.decreaseConnectionCount();
+            if (lp.getConnectionCount() <= 0) {
+                playerManager.unregisterPlayer(uuid);
+            }
         }
     }
 }

--- a/core/src/main/java/com/rexcantor64/triton/player/TritonLanguagePlayer.java
+++ b/core/src/main/java/com/rexcantor64/triton/player/TritonLanguagePlayer.java
@@ -16,6 +16,18 @@ public abstract class TritonLanguagePlayer<P> implements LanguagePlayer {
     @Getter
     private PacketEventsRefresh packetEventsRefresh;
 
+    /**
+     * Keep track of many active connections exist for this player.
+     * While it is not possible for more than one connection to exist in the PLAY phase,
+     * a user can attempt to log in with the same UUID as a player that is already in-game.
+     * Therefore, we need to know how many active connections there are to decide
+     * whether to unregister this player once they disconnect.
+     *
+     * @since 4.1.0
+     */
+    @Getter
+    private int connectionCount = 0;
+
     protected TritonLanguagePlayer() {
         if (Triton.get().getConfig().isUsePacketEvents()) {
             this.packetEventsRefresh = new PacketEventsRefresh(this);
@@ -44,5 +56,13 @@ public abstract class TritonLanguagePlayer<P> implements LanguagePlayer {
      */
     public UUID getStorageUniqueId() {
         return this.getUUID();
+    }
+
+    public void increaseConnectionCount() {
+        connectionCount += 1;
+    }
+
+    public void decreaseConnectionCount() {
+        connectionCount -= 1;
     }
 }


### PR DESCRIPTION
The UUID of User is not populated by PacketEvents in the login phase, but we can manually get it by intercepting the LOGIN_START packet on recent Minecraft versions.

There is some additional login to ensure we do not unregister logged in players.