### PR TITLE
chore!: update to adventure 5

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compileOnly libs.bungeecord.api
 
     compileOnly libs.adventure.api
-    compileOnly libs.adventure.serializer.bungeecord
+    compileOnly libs.adventure.serializer.gson
 }
 
 java {
@@ -34,7 +34,7 @@ javadoc {
             'https://hub.spigotmc.org/javadocs/spigot/',
             'https://jd.papermc.io/waterfall/1.21/', // Use Waterfall's JavaDocs instead of Bungee's since those are broken
             'https://docs.oracle.com/en/java/javase/25/docs/api/',
-            "https://jd.advntr.dev/api/${libs.adventure.api.get().version}/",
+            "https://jd.papermc.io/adventure/${libs.adventure.api.get().version}/",
     )
 
     // Disable the crazy super-strict doclint tool

--- a/api/src/main/java/com/rexcantor64/triton/api/language/LanguageParser.java
+++ b/api/src/main/java/com/rexcantor64/triton/api/language/LanguageParser.java
@@ -3,8 +3,9 @@ package com.rexcantor64.triton.api.language;
 import com.rexcantor64.triton.api.TritonAPI;
 import com.rexcantor64.triton.api.config.FeatureSyntax;
 import lombok.val;
-import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 
 /**
  * The class responsible by translating messages with placeholders
@@ -42,13 +43,13 @@ public interface LanguageParser {
         // hacky way to keep compatibility
         val result = TritonAPI.getInstance().getMessageParser()
                 .translateComponent(
-                        BungeeComponentSerializer.get().deserialize(input),
+                        GsonComponentSerializer.gson().deserialize(ComponentSerializer.toString(input)),
                         () -> TritonAPI.getInstance().getLanguageManager().getLanguageByNameOrDefault(language),
                         syntax
                 );
 
         return result.mapToObj(
-                component -> BungeeComponentSerializer.get().serialize(component),
+                component -> ComponentSerializer.parse(GsonComponentSerializer.gson().serialize(component)),
                 () -> input,
                 () -> null
         );

--- a/build-support/gen-libby-zip.nix
+++ b/build-support/gen-libby-zip.nix
@@ -6,7 +6,10 @@
 let
   inherit (pkgs) lib;
   libs = lib.importJSON libsJson;
-  repository = "https://repo.diogotc.com/mirror";
+  repositories = [
+    "https://repo.diogotc.com/mirror"
+    "https://repo.diogotc.com/releases"
+  ];
   suffix = lib.optionalString (tritonVersion != null) "-${tritonVersion}";
 
   mkJar =
@@ -24,7 +27,7 @@ let
       pname = artifactId;
       inherit version;
       src = pkgs.fetchurl {
-        url = "${repository}/${jarPath}";
+        urls = lib.map (repository: "${repository}/${jarPath}") repositories;
         hash = lib.optionalString (sha256Checksum != "") "sha256-${sha256Checksum}";
       };
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ allprojects {
     apply plugin: 'java'
     version = '4.0.2'
     java {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     tasks.withType(JavaCompile).configureEach {
         options.encoding = 'UTF-8'

--- a/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/CommonLoader.java
+++ b/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/CommonLoader.java
@@ -33,7 +33,6 @@ public class CommonLoader {
         List<Relocation> relocations = new ArrayList<>();
         if (flags.contains(LoaderFlag.VENDOR_ADVENTURE)) {
             relocations.add(new Relocation("net/kyori/adventure", "com/rexcantor64/triton/lib/adventure"));
-            relocations.add(new Relocation("net/kyori/examination", "com/rexcantor64/triton/lib/kyori/examination"));
         }
         if (flags.contains(LoaderFlag.VENDOR_ADVENTURE_NBT)) {
             relocations.add(new Relocation("net/kyori/adventure/nbt", "com/rexcantor64/triton/lib/adventure/nbt", null, Collections.singleton("net/kyori/adventure/nbt/api/*")));
@@ -41,6 +40,7 @@ public class CommonLoader {
         if (flags.contains(LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS)) {
             relocations.add(new Relocation("net/kyori/adventure/text/minimessage", "com/rexcantor64/triton/lib/adventure/text/minimessage"));
             relocations.add(new Relocation("net/kyori/adventure/text/serializer/gson", "com/rexcantor64/triton/lib/adventure/text/serializer/gson"));
+            relocations.add(new Relocation("net/kyori/adventure/text/serializer/json", "com/rexcantor64/triton/lib/adventure/text/serializer/json"));
             relocations.add(new Relocation("net/kyori/adventure/text/serializer/legacy", "com/rexcantor64/triton/lib/adventure/text/serializer/legacy"));
             relocations.add(new Relocation("net/kyori/adventure/text/serializer/plain", "com/rexcantor64/triton/lib/adventure/text/serializer/plain"));
             relocations.add(new Relocation("net/kyori/option", "com/rexcantor64/triton/lib/kyori/option"));

--- a/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/LoaderFlag.java
+++ b/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/LoaderFlag.java
@@ -1,7 +1,7 @@
 package com.rexcantor64.triton.loader.utils;
 
 public enum LoaderFlag {
-    /** Vendor the Adventure core and examination API */
+    /** Vendor the Adventure core */
     VENDOR_ADVENTURE,
     /** Vendor the Adventure NBT API */
     VENDOR_ADVENTURE_NBT,

--- a/core/src/main/java/com/rexcantor64/triton/dependencies/Dependency.java
+++ b/core/src/main/java/com/rexcantor64/triton/dependencies/Dependency.java
@@ -19,18 +19,16 @@ public enum Dependency {
     ADVENTURE(
             "net{}kyori",
             "adventure-api",
-            "4.26.1",
-            "VR5Ta56oaPMOcseQCjCbNRJO59SIn6OzrtCRApl1GiY=",
-            relocate("net{}kyori{}adventure", "adventure"),
-            relocate("net{}kyori{}examination", "kyori{}examination")
+            "5.2.0",
+            "flL+cZC+Poezs/cXEs+hIxX80nEJ8wKntEDBLwH66Cc=",
+            relocate("net{}kyori{}adventure", "adventure")
     ),
     ADVENTURE_TEXT_SERIALIZER_GSON(
             "net{}kyori",
             "adventure-text-serializer-gson",
-            "4.26.1",
-            "5KkI3txKy0MFCD2RbTYt3Csh7PRS1XegvmZSgL3a6fw=",
+            "5.2.0",
+            "WyrRyKZef6CBEnm1GkXV/FdLamNUCXtUXk/bW2iq7XM=",
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             relocate("net{}kyori{}option", "kyori{}option"),
             relocate("net{}kyori{}adventure{}text{}serializer{}gson", "adventure{}text{}serializer{}gson"),
             relocate("net{}kyori{}adventure{}text{}serializer{}json", "adventure{}text{}serializer{}json")
@@ -38,19 +36,17 @@ public enum Dependency {
     ADVENTURE_TEXT_SERIALIZER_LEGACY(
             "net{}kyori",
             "adventure-text-serializer-legacy",
-            "4.26.1",
-            "chEHvCE1ckVN8b++Q426Yw4wRXVQx1C3oVSzXcMmSqg=",
+            "5.2.0",
+            "EjGg3kF95mxZ4vKjiS7MprjUhiHfbx2aL4GwH1fjKLc=",
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             relocate("net{}kyori{}adventure{}text{}serializer{}legacy", "adventure{}text{}serializer{}legacy")
     ),
     ADVENTURE_TEXT_SERIALIZER_PLAIN(
             "net{}kyori",
             "adventure-text-serializer-plain",
-            "4.26.1",
-            "Obm/5XkPZFYF/1RkOCwOBiR29I+b+yVIgB8nXxL69AU=",
+            "5.2.0",
+            "9kJMwDimMbecxLdLazU9XQB8mbOPm+SC4MJEigDuzSE=",
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             relocate("net{}kyori{}adventure{}text{}serializer{}plain", "adventure{}text{}serializer{}plain")
     ),
     ADVENTURE_TEXT_SERIALIZER_BUNGEECORD(
@@ -59,7 +55,6 @@ public enum Dependency {
             "4.4.1",
             "4bw3bG3HohAAFgFXNc5MzFNNKya/WrgqrHUcUDIFbDk=",
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             relocate("net{}kyori{}adventure{}text{}serializer{}bungeecord", "adventure{}text{}serializer{}bungeecord"),
             relocateIf("net{}kyori{}adventure{}text{}serializer{}gson", "adventure{}text{}serializer{}gson", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),
             relocateIf("net{}kyori{}adventure{}text{}serializer{}json", "adventure{}text{}serializer{}json", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS)
@@ -67,10 +62,9 @@ public enum Dependency {
     ADVENTURE_MINI_MESSAGE(
             "net{}kyori",
             "adventure-text-minimessage",
-            "4.26.1",
-            "HUNFHpr0cyUtyK8+gIQjjVzmitQ68OO3OD6z1LY//58=",
+            "5.2.0",
+            "4YcauhUR2+Sc/yEcEPhWgohgFBYeXWKTGKppWDwxosA=",
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             relocate("net{}kyori{}option", "kyori{}option"),
             relocate("net{}kyori{}adventure{}text{}minimessage", "adventure{}text{}minimessage"),
             relocate("net{}kyori{}adventure{}text{}serializer{}gson", "adventure{}text{}serializer{}gson"),
@@ -82,43 +76,26 @@ public enum Dependency {
     ADVENTURE_KEY(
             "net{}kyori",
             "adventure-key",
-            "4.26.1",
-            "7sFy1j23e0Drer7rJfZe7eqJvTAmTQV7aLEv7Lcxvl4=",
-            relocate("net{}kyori{}adventure", "adventure"),
-            relocate("net{}kyori{}examination", "kyori{}examination")
+            "5.2.0",
+            "AYTRcyAOLu+PvHkfYi0dWP1Fn4kwxha1pP556D7abFU=",
+            relocate("net{}kyori{}adventure", "adventure")
     ),
     ADVENTURE_NBT(
             "net{}kyori",
             "adventure-nbt",
-            "4.26.1",
-            "8m72v/X83YF5ArTf01NWHZjLExtOy2c0H/AO8u0TNvg=",
+            "5.2.0",
+            "g06U1siDrF26QwVGMrw4Pu5uOb1CuhuHtrb0e8+EVUs=",
             new SimpleRelocation(relocateInner("net{}kyori{}adventure{}nbt", "adventure{}nbt", null, Collections.singleton("net{}kyori{}adventure{}nbt{}api{}*"))),
-            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE)
+            relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE)
     ),
     ADVENTURE_TEXT_SERIALIZER_JSON(
             "net{}kyori",
             "adventure-text-serializer-json",
-            "4.26.1",
-            "VcZLQzPV0paKASW48p2ufPuhU5LV+Z94266nEcsNTcI=",
+            "5.2.0",
+            "rbVBAAYXW5qmNDv63QvRHEppVe4qvBpYq+Kj+my9mrU=",
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             relocate("net{}kyori{}option", "kyori{}option"),
             relocate("net{}kyori{}adventure{}text{}serializer{}json", "adventure{}text{}serializer{}json")
-    ),
-    KYORI_EXAMINATION_API(
-            "net{}kyori",
-            "examination-api",
-            "1.3.0",
-            "ySN//ssFQo9u/4YhYkascM4LR7BMCOp8o1Ag/eV/hJI=",
-            relocate("net{}kyori{}examination", "kyori{}examination")
-    ),
-    KYORI_EXAMINATION_STRING(
-            "net{}kyori",
-            "examination-string",
-            "1.3.0",
-            "fQH8JaS7OvDhZiaFRV9FQfv0YmIW6lhG5FXBSR4Va4w=",
-            relocate("net{}kyori{}examination", "kyori{}examination")
     ),
     KYORI_OPTION(
             "net{}kyori",
@@ -132,12 +109,11 @@ public enum Dependency {
     PACKET_EVENTS_API(
             "com{}github{}retrooper",
             "packetevents-api",
-            "2.13.0",
-            "x/64iHLZBlA31FGQ3i6W9p6+A58umyix50ZpWVEH7o8=",
+            "2.13.0-triton",
+            "0Tbdp4ISSzN+H4KfTkMxLApexKZy/TpcX1P0xzLQTIw=",
             relocate("com{}github{}retrooper{}packetevents", "packetevents{}api"),
             relocate("io{}github{}retrooper{}packetevents", "packetevents{}impl"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             new ConditionalRelocation(relocateInner("net{}kyori{}adventure{}nbt", "adventure{}nbt", null, Collections.singleton("net{}kyori{}adventure{}nbt{}api{}*")), LoaderFlag.VENDOR_ADVENTURE_NBT),
             relocateIf("net{}kyori{}option", "kyori{}option", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),
             relocateIf("net{}kyori{}adventure{}text{}minimessage", "adventure{}text{}minimessage", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),
@@ -148,12 +124,11 @@ public enum Dependency {
     PACKET_EVENTS_NETTY_COMMON(
             "com{}github{}retrooper",
             "packetevents-netty-common",
-            "2.13.0",
-            "ibRP/qBRoSQq7k4HA89XIsQ29zVK2dUhSMjW7w0K6EM=",
+            "2.13.0-triton",
+            "rLMuNV7gMBFi25dXfyUYB7R7c+vGx1F5IBSB/+EbDQs=",
             relocate("com{}github{}retrooper{}packetevents", "packetevents{}api"),
             relocate("io{}github{}retrooper{}packetevents", "packetevents{}impl"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             new ConditionalRelocation(relocateInner("net{}kyori{}adventure{}nbt", "adventure{}nbt", null, Collections.singleton("net{}kyori{}adventure{}nbt{}api{}*")), LoaderFlag.VENDOR_ADVENTURE_NBT),
             relocateIf("net{}kyori{}option", "kyori{}option", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),
             relocateIf("net{}kyori{}adventure{}text{}minimessage", "adventure{}text{}minimessage", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),
@@ -164,12 +139,11 @@ public enum Dependency {
     PACKET_EVENTS_SPIGOT(
             "com{}github{}retrooper",
             "packetevents-spigot",
-            "2.13.0",
-            "LZP6ryynJN9s07c8vjxcS5Nh7lJ/FvR4xwdU6swMlpw=",
+            "2.13.0-triton",
+            "EtDA4jV/GwK0i5hbCiV6PB1X0rA1rLNoieBJN9WpVbw=",
             relocate("com{}github{}retrooper{}packetevents", "packetevents{}api"),
             relocate("io{}github{}retrooper{}packetevents", "packetevents{}impl"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             new ConditionalRelocation(relocateInner("net{}kyori{}adventure{}nbt", "adventure{}nbt", null, Collections.singleton("net{}kyori{}adventure{}nbt{}api{}*")), LoaderFlag.VENDOR_ADVENTURE_NBT),
             relocateIf("net{}kyori{}option", "kyori{}option", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),
             relocateIf("net{}kyori{}adventure{}text{}minimessage", "adventure{}text{}minimessage", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),
@@ -180,12 +154,11 @@ public enum Dependency {
     PACKET_EVENTS_BUNGEE(
             "com{}github{}retrooper",
             "packetevents-bungeecord",
-            "2.13.0",
-            "8GSB2Cnkrts29i5wJ0NHyWLWIEPoadialV3Jk1nUDYA=",
+            "2.13.0-triton",
+            "i6gF2UoxTyGthIT+TfeatnBgf3jUPIBcoujEi5RGaL4=",
             relocate("com{}github{}retrooper{}packetevents", "packetevents{}api"),
             relocate("io{}github{}retrooper{}packetevents", "packetevents{}impl"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             new ConditionalRelocation(relocateInner("net{}kyori{}adventure{}nbt", "adventure{}nbt", null, Collections.singleton("net{}kyori{}adventure{}nbt{}api{}*")), LoaderFlag.VENDOR_ADVENTURE_NBT),
             relocateIf("net{}kyori{}option", "kyori{}option", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),
             relocateIf("net{}kyori{}adventure{}text{}minimessage", "adventure{}text{}minimessage", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),
@@ -196,12 +169,11 @@ public enum Dependency {
     PACKET_EVENTS_VELOCITY(
             "com{}github{}retrooper",
             "packetevents-velocity",
-            "2.13.0",
-            "XdFvpzbQRZiYe/7Q9U+yjg3mCjUeudH5U56Fs3KmgDE=",
+            "2.13.0-triton",
+            "4h8RvCA3fDDQQ89zBqEQ5a2Lfn7XVi7IIMEpUhqhrC4=",
             relocate("com{}github{}retrooper{}packetevents", "packetevents{}api"),
             relocate("io{}github{}retrooper{}packetevents", "packetevents{}impl"),
             relocateIf("net{}kyori{}adventure", "adventure", LoaderFlag.VENDOR_ADVENTURE),
-            relocateIf("net{}kyori{}examination", "kyori{}examination", LoaderFlag.VENDOR_ADVENTURE),
             new ConditionalRelocation(relocateInner("net{}kyori{}adventure{}nbt", "adventure{}nbt", null, Collections.singleton("net{}kyori{}adventure{}nbt{}api{}*")), LoaderFlag.VENDOR_ADVENTURE_NBT),
             relocateIf("net{}kyori{}option", "kyori{}option", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),
             relocateIf("net{}kyori{}adventure{}text{}minimessage", "adventure{}text{}minimessage", LoaderFlag.VENDOR_ADVENTURE_SERIALIZERS),

--- a/core/src/main/java/com/rexcantor64/triton/dependencies/DependencyManager.java
+++ b/core/src/main/java/com/rexcantor64/triton/dependencies/DependencyManager.java
@@ -29,6 +29,7 @@ public class DependencyManager {
         }
 
         libraryManager.addRepository(Repository.DIOGOTC_MIRROR);
+        libraryManager.addRepository(Repository.DIOGOTC_RELEASES);
         libraryManager.addMavenCentral();
         libraryManager.setRelocator(new NativeRelocationHelper());
     }

--- a/core/src/main/java/com/rexcantor64/triton/dependencies/Repository.java
+++ b/core/src/main/java/com/rexcantor64/triton/dependencies/Repository.java
@@ -1,5 +1,6 @@
 package com.rexcantor64.triton.dependencies;
 
 public class Repository {
+    public final static String DIOGOTC_RELEASES = "https://repo.diogotc.com/releases/";
     public final static String DIOGOTC_MIRROR = "https://repo.diogotc.com/mirror/";
 }

--- a/core/src/main/java/com/rexcantor64/triton/language/parser/LegacyParser.java
+++ b/core/src/main/java/com/rexcantor64/triton/language/parser/LegacyParser.java
@@ -440,7 +440,7 @@ public class LegacyParser extends MessageParser {
                     }
 
                     val lowercaseChar = Character.toLowerCase(text.charAt(i));
-                    TextFormat format;
+                    @Nullable TextFormat format;
                     if (lowercaseChar == HEX_CODE && i + 12 < text.length()) {
                         val color = text.substring(i + 1, i + 13);
                         format = TextColor.fromHexString(HEX_PREFIX + color.replace(String.valueOf(SECTION_CHAR), ""));
@@ -453,17 +453,16 @@ public class LegacyParser extends MessageParser {
                         i += 9;
                         continue;
                     } else {
-                        format = CharacterAndFormat.defaults().stream()
+                        val foundFormat = CharacterAndFormat.defaults().stream()
                                 .filter(characterAndFormat -> characterAndFormat.character() == lowercaseChar)
-                                .findFirst()
-                                .map(CharacterAndFormat::format)
-                                .orElse(null);
-                    }
-                    if (format == null) {
-                        // unknown code, append color code as-is
-                        builder.append(c);
-                        i--;
-                        continue;
+                                .findFirst();
+                        if (foundFormat.isEmpty()) {
+                            // unknown code, append color code as-is
+                            builder.append(c);
+                            i--;
+                            continue;
+                        }
+                        format = foundFormat.get().format();
                     }
 
                     if (builder.length() != 0) {
@@ -477,7 +476,7 @@ public class LegacyParser extends MessageParser {
                         currentStyle = Style.style((TextColor) format);
                     } else if (format instanceof TextDecoration) {
                         currentStyle = currentStyle.decorate((TextDecoration) format);
-                    } else if (format instanceof Reset) {
+                    } else if (format == null) {
                         currentStyle = Style.empty();
                     }
                     componentBuilder.style(currentStyle);
@@ -685,7 +684,7 @@ public class LegacyParser extends MessageParser {
                 if (!this.stack[i].equals(this.linkBugStyle)) {
                     @Nullable val color = style.color();
                     if (color == null) {
-                        this.stringBuilder.append(formatToString(Reset.INSTANCE));
+                        this.stringBuilder.append(formatToString(null)); // null means reset
                     } else {
                         this.stringBuilder.append(formatToString(color));
                     }
@@ -709,7 +708,7 @@ public class LegacyParser extends MessageParser {
 
                     this.stringBuilder
                             .append(CLICK_DELIM)
-                            .append(clickEvent.action().ordinal()) // backwards compatibility only
+                            .append(0) // backwards compatibility only
                             .append(uuid);
                 }
 
@@ -762,7 +761,7 @@ public class LegacyParser extends MessageParser {
                 return this.stringBuilder.toString();
             }
 
-            private @NotNull String formatToString(@NotNull TextFormat format) {
+            private @NotNull String formatToString(@Nullable TextFormat format) {
                 if (format instanceof TextColor && !(format instanceof NamedTextColor)) {
                     // this is a hex color
                     final TextColor color = (TextColor) format;
@@ -774,7 +773,7 @@ public class LegacyParser extends MessageParser {
                     return legacy.toString();
                 }
                 return CharacterAndFormat.defaults().stream()
-                        .filter(characterAndFormat -> characterAndFormat.format().equals(format))
+                        .filter(characterAndFormat -> Objects.equals(characterAndFormat.format(), format))
                         .findFirst()
                         .map(CharacterAndFormat::character)
                         .map(c -> "" + SECTION_CHAR + c)

--- a/core/src/main/java/com/rexcantor64/triton/plugin/PluginLoader.java
+++ b/core/src/main/java/com/rexcantor64/triton/plugin/PluginLoader.java
@@ -31,8 +31,6 @@ public interface PluginLoader {
         if (depManager.hasLoaderFlag(LoaderFlag.VENDOR_ADVENTURE)) {
             depManager.loadDependency(Dependency.ADVENTURE);
             depManager.loadDependency(Dependency.ADVENTURE_KEY);
-            depManager.loadDependency(Dependency.KYORI_EXAMINATION_API);
-            depManager.loadDependency(Dependency.KYORI_EXAMINATION_STRING);
         }
         if (depManager.hasLoaderFlag(LoaderFlag.VENDOR_ADVENTURE_NBT)) {
             depManager.loadDependency(Dependency.ADVENTURE_NBT);

--- a/core/src/main/java/com/rexcantor64/triton/utils/ComponentUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/ComponentUtils.java
@@ -241,9 +241,9 @@ public class ComponentUtils {
         return component;
     }
 
-    public static boolean isValidClickEvent(ClickEvent clickEvent) {
+    public static boolean isValidClickEvent(ClickEvent<?> clickEvent) {
         return clickEvent.action() != ClickEvent.Action.OPEN_URL
-                || URL_REGEX.matcher(clickEvent.value()).find();
+                || URL_REGEX.matcher(((ClickEvent.Payload.Text) clickEvent.payload()).value()).find();
     }
 
     /**

--- a/core/src/test/java/com/rexcantor64/triton/language/parser/AdventureParserTest.java
+++ b/core/src/test/java/com/rexcantor64/triton/language/parser/AdventureParserTest.java
@@ -553,46 +553,6 @@ public class AdventureParserTest {
     }
 
     @Test
-    public void testParseComponentWhileRetainingCorrectStylesWithLinkBug() {
-        // server adds invalid link to text
-        Component comp = Component.text()
-                .append(
-                        Component.text("[lang]")
-                                .color(NamedTextColor.DARK_GRAY),
-                        Component.text("change.colors.on.args[arg]5[/arg][/lang]")
-                                .color(NamedTextColor.DARK_GRAY)
-                                .clickEvent(ClickEvent.openUrl("http://change.colors.on.args[arg]5[/arg][/lang]"))
-                )
-                .asComponent();
-
-        TranslationResult<Component> result = parser.translateComponent(comp, configuration);
-
-        Component expected = Component.text()
-                .append(
-                        Component.text()
-                                .content("")
-                                .color(NamedTextColor.DARK_GRAY), // hack because component compaction is buggy
-                        Component.text()
-                                .content("")
-                                .color(NamedTextColor.DARK_GRAY)
-                                .clickEvent(ClickEvent.openUrl("http://change.colors.on.args[arg]5[/arg][/lang]"))
-                                .append(
-                                        Component.text()
-                                                .append(
-                                                        Component.text("Some text ").color(NamedTextColor.RED),
-                                                        Component.text("5 more text").color(NamedTextColor.BLUE)
-                                                )
-                                                .asComponent()
-                                )
-                )
-                .asComponent();
-
-        assertEquals(TranslationResult.ResultState.CHANGED, result.getState());
-        assertNotNull(result.getResultRaw());
-        assertEquals(expected.compact(), result.getResultRaw().compact());
-    }
-
-    @Test
     public void testParseComponentWithNestedPlaceholders() {
         Component comp = Component.text("[lang]nested[/lang]");
 

--- a/core/src/test/java/com/rexcantor64/triton/language/parser/LegacyParserTest.java
+++ b/core/src/test/java/com/rexcantor64/triton/language/parser/LegacyParserTest.java
@@ -101,7 +101,7 @@ public class LegacyParserTest {
         assertEquals(1, serializedComponent.getHoverEvents().size());
         assertEquals(1, serializedComponent.getTranslatableComponents().size());
         assertEquals(
-                "§rLorem §0§s#DDEEFF44§lipsum dolor §r§lsit amet,§x§a§a§b§b§c§c\uE4005"
+                "§rLorem §0§s#DDEEFF44§lipsum dolor §r§lsit amet,§x§a§a§b§b§c§c\uE4000"
                         + serializedComponent.getClickEvents().keySet().iterator().next()
                         + " consectetur §x§a§a§b§b§c§c\uE800minecraft:default\uE802adipiscing \uE801§x§a§a§b§b§c§c\uE500"
                         + serializedComponent.getHoverEvents().keySet().iterator().next()
@@ -234,42 +234,6 @@ public class LegacyParserTest {
                                 .color(NamedTextColor.GREEN)
                 )
                 .build();
-
-        assertEquals(TranslationResult.ResultState.CHANGED, result.getState());
-        assertNotNull(result.getResultRaw());
-        assertEquals(expected.compact(), result.getResultRaw().compact());
-    }
-
-    @Test
-    public void testParseComponentWhileRetainingCorrectStylesWithLinkBug() {
-        // server adds invalid link to text
-        Component comp = Component.text()
-                .append(
-                        Component.text("[lang]")
-                                .color(NamedTextColor.DARK_RED),
-                        Component.text("with.placeholder.colors[arg]5[/arg][/lang]?")
-                                .clickEvent(ClickEvent.openUrl("http://with.placeholder.colors[arg]5[/arg][/lang]?"))
-                                .color(NamedTextColor.DARK_RED),
-                        // while this question mark is a separate component, this test aims to emulate the case where
-                        // it isn't supposed to be a style boundary, so it is expected that it will inherit the color
-                        // from the translation
-                        Component.text("?").color(NamedTextColor.DARK_RED)
-                )
-                .asComponent();
-
-        TranslationResult<Component> result = parser.translateComponent(new SerializedComponent(comp), configuration)
-                .map(SerializedComponent::toComponent);
-
-        Component expected = Component.text()
-                .append(
-                        Component.text()
-                                .content("5 ")
-                                .color(NamedTextColor.LIGHT_PURPLE),
-                        Component.text()
-                                .content("is a very cool guy??")
-                                .color(NamedTextColor.GREEN)
-                )
-                .asComponent();
 
         assertEquals(TranslationResult.ResultState.CHANGED, result.getState());
         assertNotNull(result.getResultRaw());

--- a/core/src/test/java/com/rexcantor64/triton/utils/ComponentSplitterTest.java
+++ b/core/src/test/java/com/rexcantor64/triton/utils/ComponentSplitterTest.java
@@ -53,7 +53,7 @@ public class ComponentSplitterTest {
                                         Component.text(" adipiscing").decorate(TextDecoration.ITALIC)
                                 ),
                         Component.text(" elit. ")
-                                .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://triton.rexcantor64.com")),
+                                .clickEvent(ClickEvent.openUrl("https://triton.rexcantor64.com")),
                         Component.text("Cras tincidunt ligula vel ante laoreet tempor.")
                                 .decoration(TextDecoration.BOLD, TextDecoration.State.FALSE)
                 )
@@ -94,7 +94,7 @@ public class ComponentSplitterTest {
                                                 Component.text("scing").decorate(TextDecoration.ITALIC)
                                         ),
                                 Component.text(" eli")
-                                        .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://triton.rexcantor64.com"))
+                                        .clickEvent(ClickEvent.openUrl("https://triton.rexcantor64.com"))
                         )
                         .asComponent(),
                 Component.text()
@@ -102,7 +102,7 @@ public class ComponentSplitterTest {
                         .decorate(TextDecoration.BOLD)
                         .append(
                                 Component.text("t. ")
-                                        .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://triton.rexcantor64.com")),
+                                        .clickEvent(ClickEvent.openUrl("https://triton.rexcantor64.com")),
                                 Component.text("Cras tincidunt ligula vel an")
                                         .decoration(TextDecoration.BOLD, TextDecoration.State.FALSE)
                         )
@@ -148,7 +148,7 @@ public class ComponentSplitterTest {
                                                 .decorate(TextDecoration.BOLD)
                                 ),
                         Component.text()
-                                .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://triton.rexcantor64.com"))
+                                .clickEvent(ClickEvent.openUrl("https://triton.rexcantor64.com"))
                                 .append(
                                         Component.text()
                                                 .content("adipiscing elit")
@@ -241,7 +241,7 @@ public class ComponentSplitterTest {
                                                         .decorate(TextDecoration.BOLD)
                                         ),
                                 Component.text()
-                                        .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://triton.rexcantor64.com"))
+                                        .clickEvent(ClickEvent.openUrl("https://triton.rexcantor64.com"))
                                         .append(
                                                 Component.text()
                                                         .content("adipi")
@@ -255,7 +255,7 @@ public class ComponentSplitterTest {
                         .decorate(TextDecoration.STRIKETHROUGH)
                         .append(
                                 Component.text()
-                                        .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://triton.rexcantor64.com"))
+                                        .clickEvent(ClickEvent.openUrl("https://triton.rexcantor64.com"))
                                         .append(
                                                 Component.text()
                                                         .content("scing e")
@@ -269,7 +269,7 @@ public class ComponentSplitterTest {
                         .decorate(TextDecoration.STRIKETHROUGH)
                         .append(
                                 Component.text()
-                                        .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://triton.rexcantor64.com"))
+                                        .clickEvent(ClickEvent.openUrl("https://triton.rexcantor64.com"))
                                         .append(
                                                 Component.text()
                                                         .content("lit")

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,13 +1,12 @@
 [versions]
-adventure = "4.26.1"
-adventure-platform = "4.4.1"
+adventure = "5.2.0"
 asm = "9.10.1"
 bstats = "3.2.1"
 bungeecord = "1.21-R0.5-SNAPSHOT"
 folia = "26.1.2.build.8-stable"
 junit = "6.1.2"
 libby = "2.1.0"
-packetevents = "2.13.0"
+packetevents = "2.13.0-triton"
 plugin-yml = "0.9.0"
 spigot = "26.2-R0.1-SNAPSHOT"
 velocity = "3.5.1"
@@ -15,7 +14,6 @@ velocity = "3.5.1"
 [libraries]
 adventure-api = { group = "net.kyori", name = "adventure-api", version.ref = "adventure" }
 adventure-nbt = { group = "net.kyori", name = "adventure-nbt", version.ref = "adventure" }
-adventure-serializer-bungeecord = { group = "net.kyori", name = "adventure-text-serializer-bungeecord", version.ref = "adventure-platform" }
 adventure-serializer-gson = { group = "net.kyori", name = "adventure-text-serializer-gson", version.ref = "adventure" }
 adventure-serializer-legacy = { group = "net.kyori", name = "adventure-text-serializer-legacy", version.ref = "adventure" }
 adventure-serializer-plain = { group = "net.kyori", name = "adventure-text-serializer-plain", version.ref = "adventure" }

--- a/triton-bungeecord/build.gradle
+++ b/triton-bungeecord/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compileOnly libs.bungeecord.api
     compileOnly libs.bungeecord.proxy
 
-    compileOnly libs.adventure.serializer.bungeecord
+    compileOnly libs.adventure.serializer.gson
 
     implementation libs.libby.bungee
 

--- a/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/utils/BaseComponentUtils.java
+++ b/triton-bungeecord/src/main/java/com/rexcantor64/triton/bungeecord/utils/BaseComponentUtils.java
@@ -1,15 +1,11 @@
 package com.rexcantor64.triton.bungeecord.utils;
 
-import com.google.gson.Gson;
-import com.rexcantor64.triton.Triton;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
-import net.md_5.bungee.api.ProxyServer;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 import org.jetbrains.annotations.NotNull;
-
-import java.lang.reflect.Field;
 
 /**
  * Utilities for {@link BaseComponent BaseComponents}.
@@ -17,22 +13,6 @@ import java.lang.reflect.Field;
  * @since 4.0.0
  */
 public class BaseComponentUtils {
-
-    static {
-        // I hate this
-        // https://github.com/KyoriPowered/adventure-platform/blob/36ab6311d9023a4f67d2db6a2e057d9ee3f8a8a7/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudiencesImpl.java#L63-L70
-        try {
-            // no need to do anything if it has failed to inject anyway
-            if (BungeeComponentSerializer.isNative()) {
-                final Field gsonField = ProxyServer.getInstance().getClass().getDeclaredField("gson");
-                gsonField.setAccessible(true);
-                final Gson gson = (Gson) gsonField.get(ProxyServer.getInstance());
-                BungeeComponentSerializer.inject(gson);
-            }
-        } catch (final Throwable error) {
-            Triton.get().getLogger().logError(error, "Failed to inject ProxyServer gson");
-        }
-    }
 
     /**
      * Convert {@link BaseComponent} to a {@link Component}.
@@ -42,7 +22,7 @@ public class BaseComponentUtils {
      * @since 4.0.0
      */
     public static @NotNull Component deserialize(@NotNull BaseComponent... components) {
-        return BungeeComponentSerializer.get().deserialize(components);
+        return GsonComponentSerializer.gson().deserialize(ComponentSerializer.toString(components));
     }
 
     /**
@@ -53,7 +33,7 @@ public class BaseComponentUtils {
      * @since 4.0.0
      */
     public static @NotNull BaseComponent @NotNull [] serialize(@NotNull Component component) {
-        return BungeeComponentSerializer.get().serialize(component);
+        return ComponentSerializer.parse(GsonComponentSerializer.gson().serialize(component));
     }
 
     /**
@@ -64,7 +44,7 @@ public class BaseComponentUtils {
      * @since 4.0.0
      */
     public static @NotNull BaseComponent serializeToSingle(@NotNull Component component) {
-        return convertArrayToSingle(BungeeComponentSerializer.get().serialize(component));
+        return convertArrayToSingle(serialize(component));
     }
 
 

--- a/triton-spigot/build.gradle
+++ b/triton-spigot/build.gradle
@@ -21,7 +21,6 @@ dependencies {
 
     compileOnly libs.adventure.serializer.gson
     compileOnly libs.adventure.serializer.legacy
-    compileOnly libs.adventure.serializer.bungeecord
 
     compileOnly libs.protocollib
     compileOnly libs.placeholderapi

--- a/triton-spigot/loader/src/main/java/com/rexcantor64/triton/loader/SpigotLoader.java
+++ b/triton-spigot/loader/src/main/java/com/rexcantor64/triton/loader/SpigotLoader.java
@@ -44,20 +44,12 @@ public class SpigotLoader extends JavaPlugin {
 
     private boolean shouldVendorAdventure() {
         try {
-            // Method only available on adventure 4.25.0+
+            // Method only available on adventure 5.0.0+
             // Finding a method instead of a class, since plugins can incorrectly shade newer versions than what is installed in the server
-            Class<?> componentClass = Class.forName("net.kyori.adventure.text.Component");
-            componentClass.getMethod("object");
+            Class<?> objectComponentClass = Class.forName("net.kyori.adventure.text.ObjectComponent");
+            objectComponentClass.getMethod("fallback");
 
-            try {
-                Class<?> objectComponentClass = Class.forName("net.kyori.adventure.text.ObjectComponent");
-                objectComponentClass.getMethod("fallback");
-                // Adventure v5+ is present and we do not support it yet!
-                return true;
-            } catch (ClassNotFoundException | NoSuchMethodException ignore) {
-                // A modern version of adventure v4 is already present
-                return false;
-            }
+            return false;
         } catch (ClassNotFoundException | NoSuchMethodException ignore) {
             // Adventure is not present or an outdated version is present
             return true;

--- a/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/utils/BaseComponentUtils.java
+++ b/triton-spigot/src/main/java/com/rexcantor64/triton/spigot/utils/BaseComponentUtils.java
@@ -1,12 +1,10 @@
 package com.rexcantor64.triton.spigot.utils;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Arrays;
 
 /**
  * Utilities for {@link BaseComponent BaseComponents}.
@@ -23,7 +21,7 @@ public class BaseComponentUtils {
      * @since 4.0.0
      */
     public static @NotNull Component deserialize(@NotNull BaseComponent... components) {
-        return BungeeComponentSerializer.get().deserialize(components);
+        return GsonComponentSerializer.gson().deserialize(ComponentSerializer.toString(components));
     }
 
     /**
@@ -34,7 +32,7 @@ public class BaseComponentUtils {
      * @since 4.0.0
      */
     public static @NotNull BaseComponent @NotNull [] serialize(@NotNull Component component) {
-        return BungeeComponentSerializer.get().serialize(component);
+        return ComponentSerializer.parse(GsonComponentSerializer.gson().serialize(component));
     }
 
 }

--- a/triton-velocity/build.gradle
+++ b/triton-velocity/build.gradle
@@ -5,11 +5,6 @@ plugins {
 
 group = 'com.rexcantor64.triton'
 
-java {
-    // Velocity wants Java 21, but we are targeting 17 for now
-    disableAutoTargetJvm()
-}
-
 dependencies {
     compileOnly project(':api')
     compileOnly project(':core')

--- a/triton-velocity/loader/build.gradle
+++ b/triton-velocity/loader/build.gradle
@@ -5,11 +5,6 @@ plugins {
 
 group = 'com.rexcantor64.triton'
 
-java {
-    // Velocity wants Java 21, but we are targeting 17 for now
-    disableAutoTargetJvm()
-}
-
 dependencies {
     compileOnly project(':core:triton-core-loader')
 


### PR DESCRIPTION
This requires a custom version of PacketEvents that is patched to support adventure 5 as well.

Additionally bumps minimum Java version to 21.

Closes #659