### PR TITLE
fix(api): add Component conversion layer when adventure is relocated

### DIFF
--- a/api/impl/build.gradle
+++ b/api/impl/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'java'
+    alias(libs.plugins.shadow)
+}
+
+group = 'com.rexcantor64.triton'
+
+dependencies {
+    compileOnly project(":api")
+    compileOnly project(":core")
+    compileOnly libs.adventure.api
+    compileOnly libs.adventure.serializer.gson
+    compileOnly libs.gson
+}
+
+shadowJar {
+    archiveFileName = 'triton-api-impl.jarinjar'
+}

--- a/api/impl/src/main/java/com/rexcantor64/triton/api/TritonAPIImpl.java
+++ b/api/impl/src/main/java/com/rexcantor64/triton/api/TritonAPIImpl.java
@@ -1,0 +1,43 @@
+package com.rexcantor64.triton.api;
+
+import com.rexcantor64.triton.Triton;
+import com.rexcantor64.triton.api.impl.adventure.TritonImpl;
+import lombok.val;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class TritonAPIImpl {
+
+    /**
+     * Register the Triton instance to be accessible from the external API.
+     *
+     * @param instance           The Triton instance currently loaded.
+     * @param adventureRelocated Whether the adventure API has been relocated, so that a conversion layer can be put in place.
+     */
+    @SuppressWarnings("unused")
+    @ApiStatus.Internal
+    public static void register(Triton<?, ?> instance, boolean adventureRelocated) {
+        // This method is called via reflection in TritonAPIUtils
+        if (adventureRelocated) {
+            register(new TritonImpl(instance));
+        } else {
+            register(instance);
+        }
+    }
+
+    private static void register(com.rexcantor64.triton.api.Triton instance) {
+        // Due to different class loaders, we cannot call TritonAPI#register directly
+        try {
+            val apiClass = Class.forName("com.rexcantor64.triton.api.TritonAPI");
+            val method = apiClass.getDeclaredMethod("register", com.rexcantor64.triton.api.Triton.class);
+            method.setAccessible(true);
+
+            method.invoke(null, instance);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException |
+                 InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/api/impl/src/main/java/com/rexcantor64/triton/api/impl/ComponentUtils.java
+++ b/api/impl/src/main/java/com/rexcantor64/triton/api/impl/ComponentUtils.java
@@ -1,0 +1,55 @@
+package com.rexcantor64.triton.api.impl;
+
+import com.google.gson.JsonElement;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import org.jetbrains.annotations.NotNullByDefault;
+
+import java.util.Arrays;
+
+@NotNullByDefault
+public class ComponentUtils {
+
+    private static final GsonComponentSerializer GSON_SERIALIZER = GsonComponentSerializer.gson();
+
+    /**
+     * Deserialize a {@link JsonElement} representing a {@link Component}.
+     *
+     * @param element The {@link JsonElement} to deserialize.
+     * @return The corresponding {@link Component}.
+     */
+    public static Component deserializeFromJsonTree(JsonElement element) {
+        return GSON_SERIALIZER.deserializeFromTree(element);
+    }
+
+    /**
+     * Serialize a {@link Component} to a {@link JsonElement}.
+     *
+     * @param component The {@link Component} to serialize.
+     * @return The corresponding {@link JsonElement}.
+     */
+    public static JsonElement serializeToJsonTree(Component component) {
+        return GSON_SERIALIZER.serializeToTree(component);
+    }
+
+    /**
+     * Deserialize an array of {@link JsonElement} representing an array of {@link Component}.
+     *
+     * @param elements The array of {@link JsonElement} to deserialize.
+     * @return The corresponding array of {@link Component}.
+     */
+    public static Component[] deserializeFromJsonTree(JsonElement... elements) {
+        return Arrays.stream(elements).map(ComponentUtils::deserializeFromJsonTree).toArray(Component[]::new);
+    }
+
+    /**
+     * Serialize an array of {@link Component} to an array of {@link JsonElement}.
+     *
+     * @param components The array of {@link Component} to serialize.
+     * @return The corresponding array of {@link JsonElement}.
+     */
+    public static JsonElement[] serializeToJsonTree(Component... components) {
+        return Arrays.stream(components).map(ComponentUtils::serializeToJsonTree).toArray(JsonElement[]::new);
+    }
+
+}

--- a/api/impl/src/main/java/com/rexcantor64/triton/api/impl/adventure/MessageParserImpl.java
+++ b/api/impl/src/main/java/com/rexcantor64/triton/api/impl/adventure/MessageParserImpl.java
@@ -1,0 +1,28 @@
+package com.rexcantor64.triton.api.impl.adventure;
+
+
+import com.rexcantor64.triton.api.config.FeatureSyntax;
+import com.rexcantor64.triton.api.impl.ComponentUtils;
+import com.rexcantor64.triton.api.language.Localized;
+import com.rexcantor64.triton.api.language.MessageParser;
+import com.rexcantor64.triton.api.language.TranslationResult;
+import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+@RequiredArgsConstructor
+public class MessageParserImpl implements MessageParser {
+
+    private final com.rexcantor64.triton.language.parser.MessageParser parser;
+
+    @Override
+    public @NotNull TranslationResult<String> translateString(@NotNull String text, @NotNull Localized language, @NotNull FeatureSyntax syntax) {
+        return parser.translateString(text, language, syntax);
+    }
+
+    @Override
+    public @NotNull TranslationResult<Component> translateComponent(@NotNull Component component, @NotNull Localized language, @NotNull FeatureSyntax syntax) {
+        return parser.translateComponentJson(ComponentUtils.serializeToJsonTree(component), language, syntax)
+                .map(ComponentUtils::deserializeFromJsonTree);
+    }
+}

--- a/api/impl/src/main/java/com/rexcantor64/triton/api/impl/adventure/TranslationManagerImpl.java
+++ b/api/impl/src/main/java/com/rexcantor64/triton/api/impl/adventure/TranslationManagerImpl.java
@@ -1,0 +1,53 @@
+package com.rexcantor64.triton.api.impl.adventure;
+
+import com.rexcantor64.triton.api.impl.ComponentUtils;
+import com.rexcantor64.triton.api.language.Localized;
+import com.rexcantor64.triton.api.language.SignLocation;
+import com.rexcantor64.triton.api.language.TranslationManager;
+import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNullByDefault;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+@RequiredArgsConstructor
+@NotNullByDefault
+public class TranslationManagerImpl implements TranslationManager {
+
+    private final com.rexcantor64.triton.language.TranslationManager manager;
+
+
+    @Override
+    public Component getTextComponentOr404(Localized locale, String key, Component... arguments) {
+        return ComponentUtils.deserializeFromJsonTree(manager.getTextComponentOr404Json(locale, key, ComponentUtils.serializeToJsonTree(arguments)));
+    }
+
+    @Override
+    public Optional<Component> getTextComponent(Localized locale, String key, Component... arguments) {
+        return manager.getTextComponentJson(locale, key, ComponentUtils.serializeToJsonTree(arguments))
+                .map(ComponentUtils::deserializeFromJsonTree);
+    }
+
+    @Override
+    public Optional<String> getTextString(Localized locale, String key) {
+        return manager.getTextString(locale, key);
+    }
+
+    @Override
+    public Optional<Component[]> getSignComponents(Localized locale, SignLocation location) {
+        return manager.getSignComponentsJson(locale, location).map(ComponentUtils::deserializeFromJsonTree);
+    }
+
+    @Override
+    public Optional<Component[]> getSignComponents(Localized locale, SignLocation location, Component[] defaultLines) {
+        return manager.getSignComponentsJson(locale, location, ComponentUtils.serializeToJsonTree(defaultLines))
+                .map(ComponentUtils::deserializeFromJsonTree);
+    }
+
+    @Override
+    public Optional<Component[]> getSignComponents(Localized locale, SignLocation location, Supplier<Component[]> defaultLinesSupplier) {
+        return manager.getSignComponentsJson(locale, location, () -> ComponentUtils.serializeToJsonTree(defaultLinesSupplier.get()))
+                .map(ComponentUtils::deserializeFromJsonTree);
+    }
+}

--- a/api/impl/src/main/java/com/rexcantor64/triton/api/impl/adventure/TritonImpl.java
+++ b/api/impl/src/main/java/com/rexcantor64/triton/api/impl/adventure/TritonImpl.java
@@ -1,0 +1,57 @@
+package com.rexcantor64.triton.api.impl.adventure;
+
+import com.rexcantor64.triton.api.Triton;
+import com.rexcantor64.triton.api.config.TritonConfig;
+import com.rexcantor64.triton.api.language.LanguageManager;
+import com.rexcantor64.triton.api.language.LanguageParser;
+import com.rexcantor64.triton.api.language.MessageParser;
+import com.rexcantor64.triton.api.language.TranslationManager;
+import com.rexcantor64.triton.api.players.LanguagePlayer;
+import com.rexcantor64.triton.api.players.PlayerManager;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TritonImpl implements Triton {
+
+    private final com.rexcantor64.triton.Triton<?, ?> triton;
+
+    @Override
+    public TritonConfig getConfig() {
+        return triton.getConfig();
+    }
+
+    @Override
+    public LanguageManager getLanguageManager() {
+        return triton.getLanguageManager();
+    }
+
+    @Override
+    public LanguageParser getLanguageParser() {
+        return triton.getLanguageParser();
+    }
+
+    @Override
+    public TranslationManager getTranslationManager() {
+        return new TranslationManagerImpl(triton.getTranslationManager());
+    }
+
+    @Override
+    public MessageParser getMessageParser() {
+        return new MessageParserImpl(triton.getMessageParser());
+    }
+
+    @Override
+    public PlayerManager getPlayerManager() {
+        return triton.getPlayerManager();
+    }
+
+    @Override
+    public void openLanguagesSelectionGUI(LanguagePlayer player) {
+        triton.openLanguagesSelectionGUI(player);
+    }
+
+    @Override
+    public void reload() {
+        triton.reload();
+    }
+}

--- a/api/src/main/java/com/rexcantor64/triton/api/TritonAPI.java
+++ b/api/src/main/java/com/rexcantor64/triton/api/TritonAPI.java
@@ -28,7 +28,7 @@ public final class TritonAPI {
     @SuppressWarnings("unused")
     @Internal
     private static void register(@NotNull Triton instance) {
-        // This method is called via reflection in TritonAPIUtils
+        // This method is called via reflection in TritonAPIImpl
         TritonAPI.instance = instance;
     }
 

--- a/api/src/main/java/com/rexcantor64/triton/api/language/TranslationManager.java
+++ b/api/src/main/java/com/rexcantor64/triton/api/language/TranslationManager.java
@@ -24,7 +24,7 @@ public interface TranslationManager {
      * @return An Adventure component of the translation with its arguments replaced, or the 404 message if the translation was not found.
      * @since 4.0.0
      */
-    @NotNull Component getTextComponentOr404(@NotNull Localized locale, @NotNull String key, Component... arguments);
+    @NotNull Component getTextComponentOr404(@NotNull Localized locale, @NotNull String key, @NotNull Component... arguments);
 
     /**
      * Get a text translation with a given key in the given language, replacing argument placeholders (%1, %2, etc.)

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation project(':triton-velocity:triton-velocity-loader')
 
     compileOnly project(':core')
+    compileOnly project(':api:api-impl')
     compileOnly project(':triton-bungeecord')
     compileOnly project(':triton-spigot')
     compileOnly project(':triton-velocity')
@@ -82,7 +83,7 @@ shadowJar {
     getArchiveBaseName().set(rootProject.name)
 
     // Include .jarinjar files in the final build
-    def modules = [':core', ':triton-bungeecord', ':triton-spigot', ':triton-velocity']
+    def modules = [':core', ':api:api-impl', ':triton-bungeecord', ':triton-spigot', ':triton-velocity']
     modules.each { path ->
         def moduleProject = project(path)
         moduleProject.afterEvaluate {

--- a/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/CommonLoader.java
+++ b/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/CommonLoader.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 @Builder
 public class CommonLoader {
     private static final String CORE_JAR_NAME = "triton-core.jarinjar";
+    private static final String API_IMPL_JAR_NAME = "triton-api-impl.jarinjar";
 
     private final String jarInJarName;
     private final String bootstrapClassName;
@@ -56,6 +57,8 @@ public class CommonLoader {
 
         @SuppressWarnings("resource")
         JarInJarClassLoader loader = new JarInJarClassLoader(getClass().getClassLoader(), relocations, CORE_JAR_NAME, jarInJarName);
+        // add API impl without relocating
+        loader.addResourceToClasspath(API_IMPL_JAR_NAME);
 
         Class<?>[] constructorTypes = this.constructorTypes.toArray(new Class<?>[this.constructorTypes.size() + 1]);
         constructorTypes[constructorTypes.length - 1] = Set.class;

--- a/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/JarInJarClassLoader.java
+++ b/core/loader/src/main/java/com/rexcantor64/triton/loader/utils/JarInJarClassLoader.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -61,6 +62,10 @@ public class JarInJarClassLoader extends URLClassLoader {
         } catch (Exception e) {
             // ignore
         }
+    }
+
+    public void addResourceToClasspath(String resource) {
+        addJarToClasspath(extractJar(getParent(), resource, Collections.emptyList()));
     }
 
     /**

--- a/core/src/main/java/com/rexcantor64/triton/Triton.java
+++ b/core/src/main/java/com/rexcantor64/triton/Triton.java
@@ -112,18 +112,18 @@ public abstract class Triton<P extends TritonLanguagePlayer<?>, B extends Bridge
 
     public void onLoad() {
         instance = this;
-        TritonAPIUtils.register(instance);
+        logger = loader.getTritonLogger();
+
+        val dependencyManager = Triton.get().getLoader().getDependencyManager();
+        TritonAPIUtils.register(instance, dependencyManager.hasLoaderFlag(LoaderFlag.VENDOR_ADVENTURE));
 
         translationsFolder = new File(getDataFolder(), "translations");
-
-        logger = loader.getTritonLogger();
 
         config = new MainConfig(this);
         configYAML = loadYAML("config", getConfigFileName());
         config.setup();
 
         if (config.isUsePacketEvents()) {
-            val dependencyManager = Triton.get().getLoader().getDependencyManager();
             val isPacketEventsVendored = dependencyManager.hasLoaderFlag(LoaderFlag.VENDOR_PACKET_EVENTS);
             if (isPacketEventsVendored) {
                 // load packet events dependency (netty and platform related modules are loaded later)

--- a/core/src/main/java/com/rexcantor64/triton/language/TranslationManager.java
+++ b/core/src/main/java/com/rexcantor64/triton/language/TranslationManager.java
@@ -1,6 +1,7 @@
 package com.rexcantor64.triton.language;
 
 import com.google.common.collect.Streams;
+import com.google.gson.JsonElement;
 import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.api.language.Language;
 import com.rexcantor64.triton.api.language.Localized;
@@ -243,9 +244,18 @@ public class TranslationManager implements com.rexcantor64.triton.api.language.T
                 .orElseGet(() -> getTranslationNotFoundComponent(key, arguments));
     }
 
+    public @NotNull JsonElement getTextComponentOr404Json(@NotNull Localized locale, @NotNull String key, JsonElement... arguments) {
+        return ComponentUtils.serializeToJsonTree(this.getTextComponentOr404(locale, key, ComponentUtils.deserializeFromJsonTree(arguments)));
+    }
+
     @Override
     public @NotNull Optional<Component> getTextComponent(@NotNull Localized locale, @NotNull String key, Component... arguments) {
         return getTextString(locale, key).map(string -> replaceArguments(handleTranslationType(string, locale.getLanguage()), arguments));
+    }
+
+    public @NotNull Optional<JsonElement> getTextComponentJson(@NotNull Localized locale, @NotNull String key, JsonElement... arguments) {
+        return this.getTextComponent(locale, key, ComponentUtils.deserializeFromJsonTree(arguments))
+                .map(ComponentUtils::serializeToJsonTree);
     }
 
     @Override
@@ -326,6 +336,24 @@ public class TranslationManager implements com.rexcantor64.triton.api.language.T
         }
 
         return getSignComponentsForLanguage(triton.getLanguageManager().getMainLanguage(), location, defaultLinesSupplier);
+    }
+
+    public @NotNull Optional<JsonElement[]> getSignComponentsJson(@NotNull Localized locale, @NotNull SignLocation location) {
+        return this.getSignComponents(locale, location).map(ComponentUtils::serializeToJsonTree);
+    }
+
+    public @NotNull Optional<JsonElement[]> getSignComponentsJson(@NotNull Localized locale,
+                                                                  @NotNull SignLocation location,
+                                                                  @NotNull JsonElement[] defaultLines) {
+        return this.getSignComponents(locale, location, ComponentUtils.deserializeFromJsonTree(defaultLines))
+                .map(ComponentUtils::serializeToJsonTree);
+    }
+
+    public @NotNull Optional<JsonElement[]> getSignComponentsJson(@NotNull Localized locale,
+                                                                  @NotNull SignLocation location,
+                                                                  @NotNull Supplier<JsonElement[]> defaultLinesSupplier) {
+        return this.getSignComponents(locale, location, () -> ComponentUtils.deserializeFromJsonTree(defaultLinesSupplier.get()))
+                .map(ComponentUtils::serializeToJsonTree);
     }
 
     private @NotNull Optional<Component[]> getSignComponentsForLanguage(@NotNull Language language,

--- a/core/src/main/java/com/rexcantor64/triton/language/parser/MessageParser.java
+++ b/core/src/main/java/com/rexcantor64/triton/language/parser/MessageParser.java
@@ -1,7 +1,9 @@
 package com.rexcantor64.triton.language.parser;
 
+import com.google.gson.JsonElement;
 import com.rexcantor64.triton.api.config.FeatureSyntax;
 import com.rexcantor64.triton.api.language.Localized;
+import com.rexcantor64.triton.utils.ComponentUtils;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,5 +34,10 @@ public abstract class MessageParser implements com.rexcantor64.triton.api.langua
     // Method has to be redeclared so that it doesn't break with jar-in-jar relocation
     @Override
     public abstract @NotNull TranslationResult<Component> translateComponent(@NotNull Component component, @NotNull Localized language, @NotNull FeatureSyntax syntax);
+
+    public @NotNull TranslationResult<JsonElement> translateComponentJson(@NotNull JsonElement component, @NotNull Localized language, @NotNull FeatureSyntax syntax) {
+        return this.translateComponent(ComponentUtils.deserializeFromJsonTree(component), language, syntax)
+                .map(ComponentUtils::serializeToJsonTree);
+    }
 
 }

--- a/core/src/main/java/com/rexcantor64/triton/utils/ComponentUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/ComponentUtils.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -100,6 +101,26 @@ public class ComponentUtils {
      */
     public static JsonElement serializeToJsonTree(@NotNull Component component) {
         return GSON_SERIALIZER.serializeToTree(component);
+    }
+
+    /**
+     * Deserialize an array of {@link JsonElement} representing an array of {@link Component}.
+     *
+     * @param elements The array of {@link JsonElement} to deserialize.
+     * @return The corresponding array of {@link Component}.
+     */
+    public static Component[] deserializeFromJsonTree(JsonElement... elements) {
+        return Arrays.stream(elements).map(ComponentUtils::deserializeFromJsonTree).toArray(Component[]::new);
+    }
+
+    /**
+     * Serialize an array of {@link Component} to an array of {@link JsonElement}.
+     *
+     * @param components The array of {@link Component} to serialize.
+     * @return The corresponding array of {@link JsonElement}.
+     */
+    public static JsonElement[] serializeToJsonTree(Component... components) {
+        return Arrays.stream(components).map(ComponentUtils::serializeToJsonTree).toArray(JsonElement[]::new);
     }
 
     /**

--- a/core/src/main/java/com/rexcantor64/triton/utils/TritonAPIUtils.java
+++ b/core/src/main/java/com/rexcantor64/triton/utils/TritonAPIUtils.java
@@ -1,6 +1,6 @@
 package com.rexcantor64.triton.utils;
 
-import com.rexcantor64.triton.api.Triton;
+import com.rexcantor64.triton.Triton;
 import com.rexcantor64.triton.api.TritonAPI;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,19 +17,20 @@ public class TritonAPIUtils {
 
     static {
         try {
-            REGISTER = TritonAPI.class.getDeclaredMethod("register", Triton.class);
+            Class<?> apiClass = Class.forName("com.rexcantor64.triton.api.TritonAPIImpl");
+            REGISTER = apiClass.getDeclaredMethod("register", Triton.class, boolean.class);
             REGISTER.setAccessible(true);
 
-        } catch (NoSuchMethodException e) {
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
             throw new RuntimeException("Failed to initialize Triton API", e);
         }
     }
 
-    public static void register(@NotNull Triton instance) {
+    public static void register(@NotNull Triton<?, ?> instance, boolean adventureRelocated) {
         try {
-            REGISTER.invoke(null, instance);
+            REGISTER.invoke(null, instance, adventureRelocated);
         } catch (Exception e) {
-            com.rexcantor64.triton.Triton.get().getLogger().logError(e, "Failed to initialize Triton API");
+            Triton.get().getLogger().logError(e, "Failed to initialize Triton API");
         }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,7 @@
 rootProject.name = 'Triton'
 include 'api'
+include 'api:impl'
+findProject(':api:impl')?.name = 'api-impl'
 include 'spigot-legacy'
 include 'core'
 include 'triton-bungeecord'


### PR DESCRIPTION
This fixes API access when Triton relocates adventure by converting between the multiple Component classes via JSON (de)serialization. This incurs a performance penalty, but appears to be the only reasonable solution.